### PR TITLE
log symlink checker

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -36,6 +36,7 @@ ADD ./src/ssh/motd /etc/motd
 ADD ./src/ssh/profile  /etc/profile
 
 ADD ./src/commands/check /usr/bin/check
+ADD ./src/commands/fix-log-symlinks /usr/bin/fix-log-symlinks
 ADD ./src/commands/tools-usage /usr/bin/tools-usage
 ADD ./src/commands/template /usr/bin/template
 

--- a/src/commands/fix-log-symlinks
+++ b/src/commands/fix-log-symlinks
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+readonly LOOP_ARG="--loop"
+readonly HELP_ARG="--help"
+readonly DEFAULT_LOOP_SLEEP=60
+
+function fix_log_symlinks() {
+  #
+  # Derived from https://github.com/kubernetes/kubernetes/issues/52172#issuecomment-346075080
+  #
+  if [ ! -d /var/lib/docker/containers ]; then
+    echo "/var/lib/docker/containers doesn't exist; aborting" 1>&2
+    exit 1
+  fi
+
+  pushd /var/lib/docker/containers
+  for DOCKER_ID in *; do
+    CONTAINER="$(cat ${DOCKER_ID}/config.v2.json | jq '{Labels:.Config.Labels, LogPath, ID}')"
+    CONTAINER_ID="$(echo ${CONTAINER} | jq -r .ID)"
+    CONTAINER_NAME="$(echo ${CONTAINER} | jq -r '.Labels["io.kubernetes.container.name"]')"
+    LOG_PATH="$(echo ${CONTAINER} | jq -r '.LogPath')"
+    POD_NAME="$(echo ${CONTAINER} | jq -r '.Labels["io.kubernetes.pod.name"]')"
+    POD_NAMESPACE="$(echo ${CONTAINER} | jq -r '.Labels["io.kubernetes.pod.namespace"]')"
+    LINK1_NAME="$(printf "%s_%s_%s-%s" "$POD_NAME" "$POD_NAMESPACE" "$CONTAINER_NAME" "$CONTAINER_ID" | cut -c 1-251)"
+    LINK1_FILENAME=$(printf "/var/log/containers/%s.log" "$LINK1_NAME")
+    LINK2_FILENAME=$(echo ${CONTAINER} | jq -r '.Labels["io.kubernetes.container.logpath"]')
+
+    if [ "${CONTAINER_NAME}" != "POD" ] ; then
+      if [ -n "${LINK1_FILENAME}" -a ! -e "${LINK1_FILENAME}" -a -e "${LOG_PATH}" ] ; then
+        echo "Missing log symlink ${LINK1_FILENAME} for ${LOG_PATH}, creating it now"
+        ln -s ${LOG_PATH} ${LINK1_FILENAME}
+      fi
+
+      if [ "${LINK2_FILENAME}" = "null" ] ; then
+        LINK2_FILENAME=""
+      fi
+      if [ -n "${LINK2_FILENAME}" -a ! -e "${LINK2_FILENAME}" -a -e "${LINK1_FILENAME}" ] ; then
+        echo "Missing log symlink ${LINK2_FILENAME} for ${LINK1_FILENAME}, creating it now"
+        if [ ! -d "$(dirname ${LINK2_FILENAME})" ] ; then
+            mkdir -p "$(dirname ${LINK2_FILENAME})"
+        fi
+        ln -s ${LINK1_FILENAME} ${LINK2_FILENAME}
+      fi
+    fi
+  done
+  popd
+}
+
+function print_help() {
+  echo "This script ensures Kuberenetes has not deleted log symlinks."
+  echo "Usage:"
+  echo "  fix-log-symlinks [options]"
+  echo
+  echo "Application options:"
+  echo -e "  --help\tprint this help"
+  echo -e "  --loop TIME\trun this command in loop, with sleep TIME in seconds, default ${DEFAULT_LOOP_SLEEP}"
+}
+
+readonly arg=${1}
+readonly loop_sleep=${2:-$DEFAULT_LOOP_SLEEP}
+
+echo "Ensure kubernetes has not deleted log symlinks"
+
+if [[ ${arg} == ${LOOP_ARG} ]]; then
+  while true; do
+    fix_log_symlinks
+    sleep ${loop_sleep}
+  done
+elif [[ ${arg} == ${HELP_ARG} ]]; then
+  print_help
+  exit 0
+else
+  fix_log_symlinks
+fi


### PR DESCRIPTION
We want to add this bash script to the kubernetes tools so that we can recreate any log symlinks that kubernetes has deleted. This is based on a known open issue as referenced in the comment in-code

The idea would be to deploy this as a cronjob to run every few minutes. Please let me know if the below change looks reasonable :) 

I've verified that the script itself seems to work fine - I built it in a separate docker image and deployed on a test cluster.

But I'm new to developing for kubernetes tools - how can I build and test this? Once I run `ci/build.sh` to build the docker image, what are the next steps for testing? Thanks team!