### PR TITLE
[receiver-mock] Add rustfmt config and make targets

### DIFF
--- a/src/rust/receiver-mock/.rustfmt.toml
+++ b/src/rust/receiver-mock/.rustfmt.toml
@@ -1,0 +1,4 @@
+reorder_imports = true
+
+hard_tabs = false
+tab_spaces = 4

--- a/src/rust/receiver-mock/Makefile
+++ b/src/rust/receiver-mock/Makefile
@@ -1,0 +1,10 @@
+RUSTFMT_FLAGS = --config-path .rustfmt.toml --edition 2018
+RUST_SOURCE_FILES = $(shell find . -name "*.rs")
+
+.PHONY: rustfmt
+rustfmt:
+	rustfmt $(RUSTFMT_FLAGS) $(RUST_SOURCE_FILES)
+
+.PHONY: check-rustfmt
+check-rustfmt:
+	rustfmt --check $(RUSTFMT_FLAGS) $(RUST_SOURCE_FILES)

--- a/src/rust/receiver-mock/src/main.rs
+++ b/src/rust/receiver-mock/src/main.rs
@@ -90,9 +90,7 @@ async fn run_app(stats: Arc<Mutex<Statistics>>, port: u16) {
         let address = conn.remote_addr().ip();
         async move {
             let statistics = statistics.clone();
-            let result = service_fn(move |req| {
-                router::handle(req, address, statistics.clone())
-            });
+            let result = service_fn(move |req| router::handle(req, address, statistics.clone()));
             Ok::<_, Infallible>(result)
         }
     });


### PR DESCRIPTION
That's an example of a check that could run on CircleCI (to get quick feedback)