### PR TITLE
Run shellcheck and tests only for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ jobs:
       script:
         - bash ci/build.sh
 
-branches:
-  only:
-    - master
-    - /^release-v\d+\.\d+$/
-    - /^v\d+\.\d+\.\d+$/
-    - /^v\d+\.\d+\.\d+-(alpha|beta|rc)\.\d+$/
+stages:
+  - name: shellcheck build.sh
+    if: type = pull_request
+  - name: test
+    if: type = pull_request
+  - name: build


### PR DESCRIPTION
This also removes `branches` section as it's marked as deprecated as per https://config.travis-ci.com/ref/job/branches

> Branches
> Include or exclude branches from being built
> 
> Include or exclude branches for your build to be run on.
> 
> This is a **legacy** setting, use the more powerful condition (if) to define branches for your build to be run on.
> 
> 