### PR TITLE
Add 2.0 migration script wrapper - upgrade-2.0 to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ FROM alpine:3.12
 ENV HELM_VERSION="3.4.2"
 ENV YQ_VERSION="3.4.1"
 ENV KUBECTL_VERSION="v1.18.14"
+ENV UPGRADE_2_0_SCRIPT_URL="https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/main/deploy/helm/sumologic/upgrade-2.0.0.sh"
 RUN set -ex \
     && apk update \
     && apk upgrade \
@@ -42,7 +43,9 @@ RUN set -ex \
     && curl -LJ https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o /usr/bin/yq \
     && chmod +x /usr/bin/yq \
     && curl -LJ https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /usr/bin/kubectl \
-    && chmod +x /usr/bin/kubectl
+    && chmod +x /usr/bin/kubectl \
+    && curl -LJ "${UPGRADE_2_0_SCRIPT_URL}" -o /usr/local/bin/upgrade-2.0.0.sh \
+    && chmod +x /usr/local/bin/upgrade-2.0.0.sh
 
 COPY \
     ./src/ssh/motd \
@@ -56,6 +59,7 @@ COPY \
     ./src/commands/tools-usage \
     ./src/commands/template \
     ./src/commands/template-dependency \
+    ./src/commands/upgrade-2.0 \
     /usr/bin/
 
 COPY ./src/commands/template-prometheus-mixin \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -48,7 +48,7 @@ function build_docker_image() {
 }
 
 function test_docker_image() {
-  local apps="stress-tester k8s-api-test receiver-mock check pvc-cleaner fix-log-symlinks tools-usage template template-dependency template-prometheus-mixin"
+  local apps="stress-tester k8s-api-test receiver-mock check pvc-cleaner fix-log-symlinks tools-usage template template-dependency template-prometheus-mixin upgrade-2.0"
 
   echo
   echo "Running docker image tests..."

--- a/src/commands/upgrade-2.0
+++ b/src/commands/upgrade-2.0
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+readonly SCRIPT_PATH="/usr/local/bin/upgrade-2.0.0.sh"
+
+function print_help() {
+  echo "2.0 k8s migration script."
+  echo "This script outputs migrated values file on stdout (and saves it in new_values.yaml in current working directory inside the container)."
+  echo "Logs produced by the migration script are available on stderr."
+  echo
+  echo "Usage:"
+  echo "  upgrade-2.0 <VALUES_FILE.yaml>"
+}
+
+function err() {
+  echo "${1}" >&2
+}
+
+set -x
+
+if [[ ${#} -ge 1 && "${1}" == "--help" ]]; then
+  print_help
+  exit 0
+fi
+
+FILE=""
+if [[ ${#} -eq 0 ]]; then
+  readonly STDIN_WAIT_S="${STDIN_WAIT_S:-10}"
+  # Take data from stdin if available and put into temporary file
+  readonly TMPFILE="$(mktemp /tmp/values.yaml.XXXXXX)"
+  # Kubectl can take some time before stdin is available for reading
+  # thats why we check if just before it's required
+  if read -t "${STDIN_WAIT_S}" REPLY; then
+    # Save first line read from stdin
+    echo "${REPLY}" > "${TMPFILE}"
+    # Save rest of the stdin
+    cat <&0 >> "${TMPFILE}"
+  fi
+
+  if [[ ! -s "${TMPFILE}" ]]; then
+    err "Values file was not provided on stdin (or it was provided empty). Aborting."
+    exit 1
+  fi
+
+  FILE="${TMPFILE}"
+else
+  FILE="${1}"
+  if [[ ! -f "${FILE}" ]]; then
+    err "Provided file \"${FILE}\" doesn't exist"
+    exit 1
+  fi
+fi
+
+# In case migration script fails we want to handle the error ourselves
+set +e
+"${SCRIPT_PATH}" "${FILE}" >&2
+readonly EXIT_STATUS=$?
+if [[ ${EXIT_STATUS} -ne 0 ]]; then
+  err "Upgrade script failed"
+  exit 1
+fi
+
+cat new_values.yaml


### PR DESCRIPTION
This script outputs migrated values file on stdout (and saves it in new_values.yaml in current working directory).
Log produced by the migration script are available on stderr.

It takes values file as input either from stdin or as first (and only) script argument (with priority for the latter).
