### PR TITLE
logs-generator: don't spin in loop just sleep till next iteration

### DIFF
--- a/src/rust/logs-generator/Makefile
+++ b/src/rust/logs-generator/Makefile
@@ -8,3 +8,11 @@ rustfmt:
 .PHONY: check-rustfmt
 check-rustfmt:
 	rustfmt --check $(RUSTFMT_FLAGS) $(RUST_SOURCE_FILES)
+
+.PHONY: build
+build:
+	cargo build --release
+
+.PHONY: build-debug
+build-debug:
+	cargo build


### PR DESCRIPTION
This PR addresses 100% CPU usage of logs generator by making it sleep when logs or bytes throughput has been reached.