### PR TITLE
ci: publish images to ECR

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -27,7 +27,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push kubernetes-tools image
+      - name: Push kubernetes-tools image to Docker Hub
         run: make push-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Push kubernetes-tools image build cache
+      - name: Push kubernetes-tools image build cache to Docker Hub
         run: make push-image-cache BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+      - name: Login to ECR
+        run: make login-ecr
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Build and push image to ECR
+        run: make push-image-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+      - name: Push kubernetes-tools image build cache to ECR
+        run: make push-image-cache-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}

--- a/.github/workflows/pre_release_builds.yml
+++ b/.github/workflows/pre_release_builds.yml
@@ -24,5 +24,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push kubernetes-tools image
+      - name: Push kubernetes-tools image to Docker Hub
         run: make push-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+      - name: Login to ECR
+        run: make login-ecr
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Build and push image to ECR
+        run: make push-image-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -22,9 +22,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push kubernetes-tools image
+      - name: Push kubernetes-tools image to Docker Hub
         run: make push-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Tag latest to point to most recent release
+      - name: Tag latest to point to most recent release in Docker Hub
         run: make tag-release-image-with-latest BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Push kubernetes-tools image build cache
+      - name: Push kubernetes-tools image build cache to Docker Hub
         run: make push-image-cache BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+      - name: Login to ECR
+        run: make login-ecr
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Build and push image to ECR
+        run: make push-image-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+      - name: Tag latest to point to most recent release in ECR
+        run: make tag-release-image-with-latest-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+      - name: Push kubernetes-tools image build cache to ECR
+        run: make push-image-cache-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ BUILD_RUST_CACHE_TAG = rust-build-cache
 IMAGE_NAME = kubernetes-tools
 DOCKERHUB_REPO_NAME = sumologic
 REPO_URL = $(DOCKERHUB_REPO_NAME)/$(IMAGE_NAME)
+ECR_URL = public.ecr.aws/a4t4y2n3
+ECR_REPO_URL = $(ECR_URL)/$(IMAGE_NAME)
 
 markdownlint: mdl
 
@@ -55,6 +57,9 @@ tag-release-image-with-latest:
 	docker tag $(IMAGE_NAME):$(BUILD_TAG) $(REPO_URL):latest
 	docker push $(REPO_URL):latest
 
+tag-release-image-with-latest-ecr:
+	make tag-release-image-with-latest REPO_URL=$(ECR_REPO_URL)
+
 test-image:
 	./scripts/test-image.sh "$(IMAGE_NAME):$(BUILD_TAG)"
 
@@ -66,9 +71,19 @@ push-image-cache:
 	docker tag $(IMAGE_NAME):$(BUILD_TAG) $(REPO_URL):dev-latest
 	docker push $(REPO_URL):dev-latest
 
+push-image-cache-ecr:
+	make push-image-cache REPO_URL=$(ECR_REPO_URL) 
+
 push-image:
 	docker tag $(IMAGE_NAME):$(BUILD_TAG) $(REPO_URL):$(BUILD_TAG)
 	docker push $(REPO_URL):$(BUILD_TAG)
 
+push-image-ecr:
+	make push-image REPO_URL=$(ECR_REPO_URL)
+
 login:
 	echo "${DOCKER_PASSWORD}" | docker login -u sumodocker --password-stdin
+
+login-ecr:
+	aws ecr-public get-login-password --region us-east-1 \
+	| docker login --username AWS --password-stdin $(ECR_URL)


### PR DESCRIPTION
Fixes: https://github.com/SumoLogic/sumologic-kubernetes-tools/issues/161

I left publishing to Dockerhub in as the default for now. I also tested this in GHA, it successfully published `public.ecr.aws/a4t4y2n3/kubernetes-tools:2.5.0-24-g74a70ad`.