### PR TITLE
ci: clean up workflows

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -1,0 +1,63 @@
+name: Build and push docker images
+
+on:
+  workflow_call:
+    inputs:
+      build_tag:
+        description: Docker tag for the built image
+        required: true
+        type: string
+      push_cache:
+        description: Should the build cache be pushed to the repository?
+        default: false
+        required: false
+        type: boolean
+      tag_latest:
+        description: Should the image be tagged with "latest" in addition to the build tag
+        default: false
+        required: false
+        type: boolean
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Build kubernetes-tools image
+        run: make build-image BUILD_TAG=${{ inputs.build_tag }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1.10.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Push kubernetes-tools image to Docker Hub
+        run: make push-image BUILD_TAG=${{ inputs.build_tag }}
+      - name: Push kubernetes-tools image build cache to Docker Hub
+        if: ${{ inputs.push_cache }}
+        run: make push-image-cache BUILD_TAG=${{ inputs.build_tag }}
+      - name: Tag latest to point to most recent release in Docker Hub
+        if: ${{ inputs.tag_latest }}
+        run: make tag-release-image-with-latest BUILD_TAG=${{ inputs.build_tag }}
+      - name: Login to ECR
+        run: make login-ecr
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Build and push image to ECR
+        run: make push-image-ecr BUILD_TAG=${{ inputs.build_tag }}
+      - name: Push kubernetes-tools image build cache to ECR
+        if: ${{ inputs.push_cache }}
+        run: make push-image-cache-ecr BUILD_TAG=${{ inputs.build_tag }}
+      - name: Tag latest to point to most recent release in ECR
+        if: ${{ inputs.tag_latest }}
+        run: make tag-release-image-with-latest-ecr BUILD_TAG=${{ inputs.build_tag }}

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -7,8 +7,10 @@ on:
       - 'release-v[0-9]+.[0-9]+'
 
 jobs:
-  build-image:
+  extract-image-tag:
     runs-on: ubuntu-20.04
+    outputs:
+      build_tag: ${{ steps.extract_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Unshallow git repo
@@ -20,23 +22,14 @@ jobs:
           echo "::set-output name=tag::$(echo ${tag#v})"
       - name: Print tag
         run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
-      - name: Build kubernetes-tools image
-        run: make build-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1.10.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push kubernetes-tools image to Docker Hub
-        run: make push-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Push kubernetes-tools image build cache to Docker Hub
-        run: make push-image-cache BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Login to ECR
-        run: make login-ecr
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - name: Build and push image to ECR
-        run: make push-image-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Push kubernetes-tools image build cache to ECR
-        run: make push-image-cache-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+  build-and-push-image:
+    uses: SumoLogic/sumologic-kubernetes-tools/.github/workflows/build_and_push_image.yml@main
+    needs: extract-image-tag
+    with:
+      build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
+      push_cache: true
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Print tag
         run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
       - name: Build kubernetes-tools image
-        run: make build-release-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+        run: make build-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
       - name: Login to Docker Hub
         uses: docker/login-action@v1.10.0
         with:

--- a/.github/workflows/pre_release_builds.yml
+++ b/.github/workflows/pre_release_builds.yml
@@ -8,8 +8,10 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
 jobs:
-  build-image:
+  extract-image-tag:
     runs-on: ubuntu-20.04
+    outputs:
+      build_tag: ${{ steps.extract_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Extract tag
@@ -17,19 +19,13 @@ jobs:
         run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
       - name: Print tag
         run: echo "Running pre release build for ${{ steps.extract_tag.outputs.tag }}"
-      - name: Build kubernetes-tools image
-        run: make build-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1.10.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push kubernetes-tools image to Docker Hub
-        run: make push-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Login to ECR
-        run: make login-ecr
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - name: Build and push image to ECR
-        run: make push-image-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+  build-and-push-image:
+    uses: SumoLogic/sumologic-kubernetes-tools/.github/workflows/build_and_push_image.yml@main
+    needs: extract-image-tag
+    with:
+      build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Print tag
         run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
       - name: Build kubernetes-tools image
-        run: make build-release-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+        run: make build-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
       - name: Login to Docker Hub
         uses: docker/login-action@v1.10.0
         with:

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -26,8 +26,6 @@ jobs:
         run: make push-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
       - name: Tag latest to point to most recent release in Docker Hub
         run: make tag-release-image-with-latest BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Push kubernetes-tools image build cache to Docker Hub
-        run: make push-image-cache BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
       - name: Login to ECR
         run: make login-ecr
         env:
@@ -37,5 +35,3 @@ jobs:
         run: make push-image-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
       - name: Tag latest to point to most recent release in ECR
         run: make tag-release-image-with-latest-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Push kubernetes-tools image build cache to ECR
-        run: make push-image-cache-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -6,8 +6,10 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  build-image:
+  extract-image-tag:
     runs-on: ubuntu-20.04
+    outputs:
+      build_tag: ${{ steps.extract_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v2.4.0
       - name: Extract tag
@@ -15,23 +17,14 @@ jobs:
         run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
       - name: Print tag
         run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
-      - name: Build kubernetes-tools image
-        run: make build-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1.10.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push kubernetes-tools image to Docker Hub
-        run: make push-image BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Tag latest to point to most recent release in Docker Hub
-        run: make tag-release-image-with-latest BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Login to ECR
-        run: make login-ecr
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - name: Build and push image to ECR
-        run: make push-image-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
-      - name: Tag latest to point to most recent release in ECR
-        run: make tag-release-image-with-latest-ecr BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+  build-and-push-image:
+    uses: SumoLogic/sumologic-kubernetes-tools/.github/workflows/build_and_push_image.yml@main
+    needs: extract-image-tag
+    with:
+      build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
+      tag_latest: true
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -35,24 +35,6 @@ build-image:
 		--tag $(IMAGE_NAME):$(BUILD_TAG) \
 		.
 
-build-release-image:
-	DOCKER_BUILDKIT=1 docker build \
-		--build-arg BUILDKIT_INLINE_CACHE=1 \
-		--target go-builder \
-		--tag $(IMAGE_NAME):$(BUILD_GO_CACHE_TAG) \
-		.
-
-	DOCKER_BUILDKIT=1 docker build \
-		--build-arg BUILDKIT_INLINE_CACHE=1 \
-		--target rust-builder \
-		--tag $(IMAGE_NAME):$(BUILD_RUST_CACHE_TAG) \
-		.
-
-	DOCKER_BUILDKIT=1 docker build \
-		--build-arg BUILDKIT_INLINE_CACHE=1 \
-		--tag $(IMAGE_NAME):$(BUILD_TAG) \
-		.
-
 tag-release-image-with-latest:
 	docker tag $(IMAGE_NAME):$(BUILD_TAG) $(REPO_URL):latest
 	docker push $(REPO_URL):latest


### PR DESCRIPTION
Clean up the CI logic and workflows:
* always use cache when building images
* only push cache to registries in the dev workflow
* add a reusable workflow for building and pushing images, use it in other workflows to keep things DRY

The reusable workflow requires moving tag computation to a separate job, whose output is then used as an input to the build/push job. This is simply how reusable workflows work in GHA. There's a question of whether the reference to the reusable workflow should be pinned to a specific revision rather than following main, but since we control this, I think it's fine the way it is, and much easier to manage.

Should the dev workflow really be run on `release-v[0-9]+.[0-9]+`, by the way? Do we use release branches in this repo?