### PR TITLE
Build multiplatform docker images

### DIFF
--- a/.github/workflows/build_and_push_image.yml
+++ b/.github/workflows/build_and_push_image.yml
@@ -33,18 +33,25 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2.4.0
-      - name: Build kubernetes-tools image
-        run: make build-image BUILD_TAG=${{ inputs.build_tag }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.2.0
+      - name: Set up Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1.6.0
+      - name: Show Buildx platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
       - name: Login to Docker Hub
         uses: docker/login-action@v1.10.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push kubernetes-tools image to Docker Hub
-        run: make push-image BUILD_TAG=${{ inputs.build_tag }}
-      - name: Push kubernetes-tools image build cache to Docker Hub
+      # only push cache to Dockerhub as ECR doesn't support it yet
+      # https://github.com/aws/containers-roadmap/issues/876
+      - name: Build and push image build cache to Docker Hub
         if: ${{ inputs.push_cache }}
-        run: make push-image-cache BUILD_TAG=${{ inputs.build_tag }}
+        run: make push-image-cache
+      - name: Build and push image to Docker Hub
+        run: make push-image BUILD_TAG=${{ inputs.build_tag }}
       - name: Tag latest to point to most recent release in Docker Hub
         if: ${{ inputs.tag_latest }}
         run: make tag-release-image-with-latest BUILD_TAG=${{ inputs.build_tag }}
@@ -55,9 +62,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Build and push image to ECR
         run: make push-image-ecr BUILD_TAG=${{ inputs.build_tag }}
-      - name: Push kubernetes-tools image build cache to ECR
-        if: ${{ inputs.push_cache }}
-        run: make push-image-cache-ecr BUILD_TAG=${{ inputs.build_tag }}
       - name: Tag latest to point to most recent release in ECR
         if: ${{ inputs.tag_latest }}
         run: make tag-release-image-with-latest-ecr BUILD_TAG=${{ inputs.build_tag }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 BUILD_TAG ?= dev-latest
-BUILD_GO_CACHE_TAG = go-build-cache
-BUILD_RUST_CACHE_TAG = rust-build-cache
 IMAGE_NAME = kubernetes-tools
 DOCKERHUB_REPO_NAME = sumologic
 REPO_URL = $(DOCKERHUB_REPO_NAME)/$(IMAGE_NAME)
@@ -13,31 +11,13 @@ mdl:
 	mdl --style .markdownlint/style.rb .
 
 build-image:
-	DOCKER_BUILDKIT=1 docker build \
-		--build-arg BUILDKIT_INLINE_CACHE=1 \
-		--cache-from $(REPO_URL):$(BUILD_GO_CACHE_TAG) \
-		--target go-builder \
-		--tag $(IMAGE_NAME):$(BUILD_GO_CACHE_TAG) \
-		.
+	TAG=$(BUILD_TAG) docker buildx bake
 
-	DOCKER_BUILDKIT=1 docker build \
-		--build-arg BUILDKIT_INLINE_CACHE=1 \
-		--cache-from $(REPO_URL):$(BUILD_RUST_CACHE_TAG) \
-		--target rust-builder \
-		--tag $(IMAGE_NAME):$(BUILD_RUST_CACHE_TAG) \
-		.
-
-	DOCKER_BUILDKIT=1 docker build \
-		--build-arg BUILDKIT_INLINE_CACHE=1 \
-		--cache-from $(REPO_URL):$(BUILD_GO_CACHE_TAG) \
-		--cache-from $(REPO_URL):$(BUILD_RUST_CACHE_TAG) \
-		--cache-from $(REPO_URL):dev-latest \
-		--tag $(IMAGE_NAME):$(BUILD_TAG) \
-		.
+build-image-multiplatform:
+	TAG=$(BUILD_TAG) docker buildx bake tools-multiplatform 
 
 tag-release-image-with-latest:
-	docker tag $(IMAGE_NAME):$(BUILD_TAG) $(REPO_URL):latest
-	docker push $(REPO_URL):latest
+	make push-image BUILD_TAG=latest
 
 tag-release-image-with-latest-ecr:
 	make tag-release-image-with-latest REPO_URL=$(ECR_REPO_URL)
@@ -46,19 +26,12 @@ test-image:
 	./scripts/test-image.sh "$(IMAGE_NAME):$(BUILD_TAG)"
 
 push-image-cache:
-	docker tag $(IMAGE_NAME):$(BUILD_GO_CACHE_TAG) $(REPO_URL):$(BUILD_GO_CACHE_TAG)
-	docker push $(REPO_URL):$(BUILD_GO_CACHE_TAG)
-	docker tag $(IMAGE_NAME):$(BUILD_RUST_CACHE_TAG) $(REPO_URL):$(BUILD_RUST_CACHE_TAG)
-	docker push $(REPO_URL):$(BUILD_RUST_CACHE_TAG)
-	docker tag $(IMAGE_NAME):$(BUILD_TAG) $(REPO_URL):dev-latest
-	docker push $(REPO_URL):dev-latest
-
-push-image-cache-ecr:
-	make push-image-cache REPO_URL=$(ECR_REPO_URL) 
+	# only push cache to Dockerhub as ECR doesn't support it yet
+    	# https://github.com/aws/containers-roadmap/issues/876
+	docker buildx bake cache-multiplatform
 
 push-image:
-	docker tag $(IMAGE_NAME):$(BUILD_TAG) $(REPO_URL):$(BUILD_TAG)
-	docker push $(REPO_URL):$(BUILD_TAG)
+	IMAGE=$(REPO_URL) TAG=$(BUILD_TAG) docker buildx bake tools-multiplatform --push
 
 push-image-ecr:
 	make push-image REPO_URL=$(ECR_REPO_URL)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,87 @@
+variable "IMAGE" {
+    default = "kubernetes-tools"
+}
+
+variable "TAG" {
+    default = "dev-latest"
+}
+
+variable "CACHE_IMAGE" {
+    default = "sumologic/kubernetes-tools"
+}
+
+variable "BUILD_GO_CACHE_TAG" {
+    default = "go-build-cache"
+}
+
+variable "BUILD_RUST_CACHE_TAG" {
+    default = "rust-build-cache"
+}
+
+variable "TOOLS_CACHE_TAG" {
+    default = "tools-build-cache"
+}
+
+target "multiplatform" {
+    platforms = ["linux/amd64", "linux/arm64"]
+    output = ["type=image"]
+}
+
+target "default" {
+    dockerfile = "Dockerfile"
+    tags = ["${IMAGE}:${TAG}"]
+    cache-from = [
+        "${CACHE_IMAGE}:${BUILD_GO_CACHE_TAG}",
+        "${CACHE_IMAGE}:${BUILD_RUST_CACHE_TAG}",
+        "${CACHE_IMAGE}:${TOOLS_CACHE_TAG}",
+    ]
+    output = ["type=docker"]
+    platforms = ["linux/amd64"]
+}
+
+target "tools-multiplatform" {
+    inherits = ["default", "multiplatform"]
+}
+
+group "cache" {
+    targets = ["rust-cache", "go-cache", "tools-cache"]
+}
+
+target "rust-cache" {
+    dockerfile = "Dockerfile"
+    cache-from = [
+        "${CACHE_IMAGE}:${BUILD_RUST_CACHE_TAG}",
+    ]
+    cache-to = ["${CACHE_IMAGE}:${BUILD_RUST_CACHE_TAG}"]
+    target = "rust-builder"
+}
+
+target "go-cache" {
+    dockerfile = "Dockerfile"
+    cache-from = [
+        "${CACHE_IMAGE}:${BUILD_GO_CACHE_TAG}",
+    ]
+    cache-to = ["${CACHE_IMAGE}:${BUILD_GO_CACHE_TAG}"]
+    target = "go-builder"
+}
+
+target "tools-cache" {
+    inherits = ["default"]
+    cache-to = ["${CACHE_IMAGE}:${TOOLS_CACHE_TAG}"]
+}
+
+group "cache-multiplatform" {
+    targets = ["rust-cache-multiplatform", "go-cache-multiplatform", "tools-cache-multiplatform"]
+}
+
+target "rust-cache-multiplatform" {
+    inherits = ["rust-cache", "multiplatform"]
+}
+
+target "go-cache-multiplatform" {
+    inherits = ["go-cache", "multiplatform"]
+}
+
+target "tools-cache-multiplatform" {
+    inherits = ["tools-cache", "multiplatform"]
+}


### PR DESCRIPTION
More specifically, this is for ARMv8 support, though we can technically build for any platform supported by QEMU, rust, and go.

Use docker buildx for building the images, and organize the build targets in a `docker-bake.hcl` file for `docker buildx bake`. This allowed the Makefile to become simpler while encapsulating all the Docker-specific bits in a separate file. buildx also had superior build cache management, which unfotunately doesn't work on ECR yet, so for the time being we use Dockerhub exclusively for cache.

In the CI workflow, I switched from the "build once and push to multiple destinations" flow to "build and push to each destination in a single command". Build cache means we only build images once either way, and the latter fits the semantics of buildx better.

See successful CI build here: https://github.com/SumoLogic/sumologic-kubernetes-tools/runs/4333036971 and you can run 
```bash
docker manifest inspect --verbose sumologic/kubernetes-tools:latest
```
to see the multiplatform manifest.