### PR TITLE
ci(codeowners): use team name only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Learn about CODEOWNERS file format:
 #  https://help.github.com/en/articles/about-code-owners
 
-* @astencel-sumo @kkujawa-sumo @perk-sumo @pmalek-sumo @sumo-drosiek
+* @SumoLogic/open-source-collection-team


### PR DESCRIPTION
Similar to what we do in other repos:
- https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/v2.2.0/.github/CODEOWNERS
- https://github.com/SumoLogic/sumologic-kubernetes-fluentd/blob/v1.12.2-sumo-9/.github/CODEOWNERS
- https://github.com/SumoLogic/sumologic-kubernetes-setup/blob/afce3bb5a85b8d67a02bbb069bfb5c09b68aee2c/.github/CODEOWNERS