### PR TITLE
Add log counting by timestamp range to receiver-mock

### DIFF
--- a/src/rust/receiver-mock/Cargo.lock
+++ b/src/rust/receiver-mock/Cargo.lock
@@ -309,6 +309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
+
+[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1336,7 @@ dependencies = [
  "actix-rt 2.5.0",
  "actix-service",
  "actix-web",
+ "anyhow",
  "bytes 1.1.0",
  "chrono",
  "clap",
@@ -1337,6 +1344,7 @@ dependencies = [
  "prometheus-parse",
  "rand 0.8.4",
  "serde",
+ "serde_json",
  "timer",
 ]
 

--- a/src/rust/receiver-mock/Cargo.toml
+++ b/src/rust/receiver-mock/Cargo.toml
@@ -11,8 +11,10 @@ actix-web = "3.3.2"
 actix-http = "2.2.1"
 actix-service = "1"
 actix-rt = "2"
+anyhow = "1.0.51"
 bytes = "1"
 serde = { version ="1.0.131" , features = ["derive"] }
+serde_json = "1.0.59"
 clap = "2.34.0"
 timer = "0.2"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src/rust/receiver-mock/README.md
+++ b/src/rust/receiver-mock/README.md
@@ -26,9 +26,9 @@ Example output:
 {"source":{"url":"http://localhost:3333/receiver"}}
 ```
 
-## Statistics
+## Metrics
 
-There are endpoints which provides statistics:
+These are endpoints which provide information about received metrics:
 
 - `metrics` - exposes receiver-mock metrics in prometheus format
 
@@ -91,6 +91,20 @@ There are endpoints which provides statistics:
         "timestamp": 163123123
       }
     ]
+## Logs
+
+These following endpoints provide information about received logs:
+
+- `/logs/count?from_ts=1&to_ts=1000`
+
+  Returns the number of logs received between `from_ts` and `to_ts`. The values are epoch timestamps in milliseconds, and the range represented by them is inclusive at the start and exclusive at the end. Both values are optional.
+
+  ```json
+
+  {
+      "count": 7
+  }
+
   ```
 
 ## Disclaimer

--- a/src/rust/receiver-mock/README.md
+++ b/src/rust/receiver-mock/README.md
@@ -91,20 +91,20 @@ These are endpoints which provide information about received metrics:
         "timestamp": 163123123
       }
     ]
+  ```
+
 ## Logs
 
-These following endpoints provide information about received logs:
+The following endpoints provide information about received logs:
 
 - `/logs/count?from_ts=1&to_ts=1000`
 
   Returns the number of logs received between `from_ts` and `to_ts`. The values are epoch timestamps in milliseconds, and the range represented by them is inclusive at the start and exclusive at the end. Both values are optional.
 
   ```json
-
   {
-      "count": 7
+    "count": 7
   }
-
   ```
 
 ## Disclaimer

--- a/src/rust/receiver-mock/src/logs.rs
+++ b/src/rust/receiver-mock/src/logs.rs
@@ -1,4 +1,6 @@
-use std::collections::HashMap;
+use anyhow::{anyhow, Error};
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap};
 use std::net::IpAddr;
 
 #[derive(Clone)]
@@ -8,9 +10,15 @@ pub struct LogStats {
 }
 
 #[derive(Clone)]
+pub struct LogMessage {
+    // TODO: add body here once there's an API to query it
+}
+
+#[derive(Clone)]
 pub struct LogRepository {
     pub total: LogStats,
     pub ipaddr_to_stats: HashMap<IpAddr, LogStats>,
+    pub messages_by_ts: BTreeMap<u64, Vec<LogMessage>>, // indexed by timestamp to make range queries possible
 }
 
 impl LogRepository {
@@ -18,18 +26,41 @@ impl LogRepository {
         return Self {
             total: LogStats { count: 0, bytes: 0 },
             ipaddr_to_stats: HashMap::new(),
+            messages_by_ts: BTreeMap::new(),
         };
     }
 
-    pub fn add_log_message(&mut self, body: String, ipaddr: IpAddr) {
+    pub fn add_log_message(&mut self, body: String, ipaddr: IpAddr) -> Result<(), Error> {
+        // add the log message to the time index
+        let timestamp = match get_timestamp_from_body(&body) {
+            Some(ts) => ts,
+            None => return Err(anyhow!("No timestamp found in log message")),
+        };
+        let messages = self.messages_by_ts.entry(timestamp).or_insert(Vec::new());
+        messages.push(LogMessage {});
+
+        // update total stats
         self.total.count += 1;
         self.total.bytes += body.len() as u64;
+
+        // update per ip address stats
         let stats = self
             .ipaddr_to_stats
             .entry(ipaddr)
             .or_insert(LogStats { count: 0, bytes: 0 });
         stats.count += 1;
         stats.bytes += body.len() as u64;
+
+        Ok(())
+    }
+
+    pub fn get_message_count(&self, from_ts: u64, to_ts: u64) -> u32 {
+        let mut count = 0;
+        let entries = self.messages_by_ts.range(from_ts..to_ts);
+        for (_, messages) in entries {
+            count += messages.len()
+        }
+        return count as u32;
     }
 
     pub fn get_stats_for_ipaddr(&self, ipaddr: IpAddr) -> LogStats {
@@ -41,6 +72,18 @@ impl LogRepository {
     }
 }
 
+// Try to get the timestamp from the log body
+// We only handle the case where the log is a JSON string representing a map with "timestamp" as a
+// top-level key.
+fn get_timestamp_from_body(body: &str) -> Option<u64> {
+    let parsed_body: Value = match serde_json::from_str(body) {
+        Ok(result) => result,
+        Err(_) => return None,
+    };
+    let timestamp = &parsed_body["timestamp"];
+    return timestamp.as_u64();
+}
+
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
@@ -48,14 +91,15 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
     #[test]
-    fn test_add_message() {
+    fn test_repo_add_message_valid() {
         let ip_address = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
         let mut repository = LogRepository::new();
         let old_repository = repository.clone();
-        let body = "Log message";
+        let body = r#"{"log": "Log message", "timestamp": 1}"#;
 
-        repository.add_log_message(body.to_string(), ip_address);
+        let result = repository.add_log_message(body.to_string(), ip_address);
 
+        assert!(result.is_ok());
         assert_eq!(repository.total.count, old_repository.total.count + 1);
         assert_eq!(
             repository.total.bytes,
@@ -70,5 +114,49 @@ mod tests {
             repository.ipaddr_to_stats[&ip_address].bytes,
             old_repository.get_stats_for_ipaddr(ip_address).bytes + body.len() as u64
         );
+    }
+
+    #[test]
+    fn test_repo_add_message_invalid() {
+        let ip_address = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let mut repository = LogRepository::new();
+        let body_without_ts = r#"{"log": "Log message"}"#;
+
+        let result = repository.add_log_message(body_without_ts.to_string(), ip_address);
+
+        assert!(result.is_err());
+        assert_eq!(repository.total.count, 0);
+    }
+
+    #[test]
+    fn test_repo_range_query() {
+        let ip_address = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let mut repository = LogRepository::new();
+        let timestamps = [1, 5, 8];
+        let bodies = timestamps
+            .iter()
+            .map(|ts| format!("{{\"log\": \"Log message\", \"timestamp\": {}}}", ts));
+
+        for body in bodies {
+            let result = repository.add_log_message(body.to_string(), ip_address);
+            assert!(result.is_ok());
+        }
+
+        assert_eq!(repository.total.count, 3);
+        assert_eq!(repository.get_message_count(1, 6), 2);
+        assert_eq!(repository.get_message_count(0, 10), 3);
+        assert_eq!(repository.get_message_count(2, 3), 0);
+    }
+
+    #[test]
+    fn test_get_timestamp_from_body() {
+        assert_eq!(
+            get_timestamp_from_body(r#"{"timestamp": 1234567891011}"#).unwrap(),
+            1234567891011
+        );
+        assert!(get_timestamp_from_body(r#"{"timestamp": -1}"#).is_none());
+        assert!(get_timestamp_from_body(r#"{"timestamp": 1.5}"#).is_none());
+        assert!(get_timestamp_from_body(r#"{"log": "Some log message"}"#).is_none());
+        assert!(get_timestamp_from_body("Not json at all").is_none())
     }
 }

--- a/src/rust/receiver-mock/src/main.rs
+++ b/src/rust/receiver-mock/src/main.rs
@@ -129,6 +129,7 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
                 web::get().to(router::handler_metrics_samples),
             )
             .route("/metrics", web::get().to(router::handler_metrics))
+            .route("/logs/count", web::get().to(router::handler_logs_count))
             .service(
                 web::scope("/terraform")
                     .app_data(app_metadata.clone())

--- a/src/rust/receiver-mock/src/main.rs
+++ b/src/rust/receiver-mock/src/main.rs
@@ -65,6 +65,13 @@ async fn main() -> std::io::Result<()> {
           .help("Use to store metrics which will then be returned via /metrics-samples")
           .takes_value(false)
           .required(false))
+      .arg(Arg::with_name("store_logs")
+          .short("sl")
+          .long("store-logs")
+          .value_name("store_logs")
+          .help("Use to store log data which can then be queried via /logs/* endpoints")
+          .takes_value(false)
+          .required(false))
       .arg(Arg::with_name("drop_rate")
           .short("d")
           .long("drop-rate")
@@ -85,6 +92,7 @@ async fn main() -> std::io::Result<()> {
         },
         drop_rate: drop_rate,
         store_metrics: matches.is_present("store_metrics"),
+        store_logs: matches.is_present("store_logs"),
     };
 
     run_app(hostname, port, opts).await

--- a/src/rust/receiver-mock/src/metrics.rs
+++ b/src/rust/receiver-mock/src/metrics.rs
@@ -312,6 +312,7 @@ mem_free{host="myhostname"} 1.190197248e+10"##
             },
             drop_rate: 0,
             store_metrics: false,
+            store_logs: true,
         };
         let result = handle_prometheus(lines, ip_address, &opts);
 

--- a/src/rust/receiver-mock/src/options.rs
+++ b/src/rust/receiver-mock/src/options.rs
@@ -3,6 +3,7 @@ pub struct Options {
     pub print: Print,
     pub drop_rate: i64,
     pub store_metrics: bool,
+    pub store_logs: bool,
 }
 
 #[derive(Clone, Copy)]

--- a/src/rust/receiver-mock/src/router.rs
+++ b/src/rust/receiver-mock/src/router.rs
@@ -440,7 +440,12 @@ pub async fn handler_receiver(
             {
                 let mut log_repository = app_state.logs.write().unwrap();
                 for line in lines.clone() {
-                    log_repository.add_log_message(line.to_string(), remote_address)
+                    match log_repository.add_log_message(line.to_string(), remote_address) {
+                        Ok(_) => (),
+                        Err(error) => {
+                            eprintln!("error `{}` encountered when parsing {}", error, line)
+                        }
+                    }
                 }
             }
             if opts.print.logs {

--- a/src/rust/receiver-mock/src/time.rs
+++ b/src/rust/receiver-mock/src/time.rs
@@ -2,8 +2,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn get_now() -> u64 {
     let start = SystemTime::now();
-    let since_the_epoch = start
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards");
+    let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards");
     return since_the_epoch.as_secs() as u64;
 }

--- a/src/rust/receiver-mock/src/time.rs
+++ b/src/rust/receiver-mock/src/time.rs
@@ -5,3 +5,10 @@ pub fn get_now() -> u64 {
     let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards");
     return since_the_epoch.as_secs() as u64;
 }
+
+// Get the current system time as a epoch timestamp in milliseconds
+pub fn get_now_ms() -> u64 {
+    let start = SystemTime::now();
+    let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards");
+    return since_the_epoch.as_millis() as u64;
+}


### PR DESCRIPTION
We count logs by timestamp in a BTreeMap and expose the number via a `/logs/count` endpoint. It is assumed at the moment that the log body is a json object and that the timestamp is contained in the `timestamp` key.

The plan is to store metadata and allow filtering by it as well in the very near future.