### PR TITLE
refactor(receiver-mock): refactor tests

### DIFF
--- a/src/rust/receiver-mock/Cargo.lock
+++ b/src/rust/receiver-mock/Cargo.lock
@@ -1382,7 +1382,6 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
- "futures-util",
  "json_str",
  "prometheus-parse",
  "rand 0.8.4",

--- a/src/rust/receiver-mock/Cargo.toml
+++ b/src/rust/receiver-mock/Cargo.toml
@@ -17,7 +17,6 @@ serde_derive = "1"
 clap = "2.34.0"
 timer = "0.2"
 futures = "^0.3"
-futures-util = "^0.3"
 chrono = { version = "^0.4", features = ["serde"] }
 json_str = "*"
 rand = "^0.8"


### PR DESCRIPTION
Mostly simplify tests code, replace `test::load_stream(resp.take_body().into_stream())` into `test::read_body(resp)` (and remove unneeded now `futures-util`) and indent multiline strings.