### PR TITLE
Filter logs by metadata in receiver-mock

### DIFF
--- a/src/rust/receiver-mock/README.md
+++ b/src/rust/receiver-mock/README.md
@@ -97,9 +97,12 @@ These are endpoints which provide information about received metrics:
 
 The following endpoints provide information about received logs:
 
-- `/logs/count?from_ts=1&to_ts=1000`
+- `/logs/count?from_ts=1&to_ts=1000&namespace=default&deployment=`
 
   Returns the number of logs received between `from_ts` and `to_ts`. The values are epoch timestamps in milliseconds, and the range represented by them is inclusive at the start and exclusive at the end. Both values are optional.
+
+  It's also possible to filter by log metadata. Any query parameter without a fixed meaning (such as `from_ts`) will be treated
+  as a key-value pair of metadata, and only logs containing that pair will be counted. Similarly to the metrics samples endpoint, an empty value is treated as a wildcard.
 
   ```json
   {

--- a/src/rust/receiver-mock/src/logs.rs
+++ b/src/rust/receiver-mock/src/logs.rs
@@ -115,6 +115,28 @@ fn get_timestamp_from_body(body: &str) -> Option<u64> {
     return timestamp.as_u64();
 }
 
+/// Parse the value of the X-Sumo-Fields header into a map of field name to field value
+fn parse_sumo_fields_header_value(header_value: &str) -> Result<HashMap<String, String>, anyhow::Error> {
+    let mut field_values = HashMap::new();
+    if header_value.trim().len() == 0 {
+        return Ok(field_values);
+    }
+    for entry in header_value.split(",") {
+        match entry.trim().split_once("=") {
+            Some((field_name, field_value)) => {
+                field_values.insert(field_name.to_string(), field_value.to_string())
+            }
+            None => {
+                return Err(anyhow!(
+                    "Failed to parse X-Sumo-Fields, no `=` in {}",
+                    entry
+                ))
+            }
+        };
+    }
+    return Ok(field_values);
+}
+
 #[cfg(test)]
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
@@ -191,5 +213,47 @@ mod tests {
         assert!(get_timestamp_from_body(r#"{"timestamp": 1.5}"#).is_none());
         assert!(get_timestamp_from_body(r#"{"log": "Some log message"}"#).is_none());
         assert!(get_timestamp_from_body("Not json at all").is_none())
+    }
+
+    #[test]
+    fn test_parse_sumo_fields_valid() {
+        let single_pair = "_collector=test";
+        assert_eq!(
+            parse_sumo_fields_header_value(single_pair).unwrap(),
+            HashMap::from([(String::from("_collector"), String::from("test"))])
+        );
+
+        let multiple_pairs = "service=collection-kube-state-metrics, deployment=collection-kube-state-metrics, node=sumologic-control-plane";
+        assert_eq!(
+            parse_sumo_fields_header_value(multiple_pairs).unwrap(),
+            HashMap::from([
+                (
+                    String::from("service"),
+                    String::from("collection-kube-state-metrics")
+                ),
+                (
+                    String::from("deployment"),
+                    String::from("collection-kube-state-metrics")
+                ),
+                (
+                    String::from("node"),
+                    String::from("sumologic-control-plane")
+                )
+            ])
+        );
+
+        let empty = "";
+        assert_eq!(
+            parse_sumo_fields_header_value(empty).unwrap(),
+            HashMap::new()
+        );
+    }
+
+    #[test]
+    fn test_parse_sumo_fields_invalid() {
+        let invalid_inputs = [",", "no_equals"];
+        for input in invalid_inputs {
+            assert!(parse_sumo_fields_header_value(input).is_err())
+        }
     }
 }

--- a/src/rust/receiver-mock/src/main.rs
+++ b/src/rust/receiver-mock/src/main.rs
@@ -15,6 +15,7 @@ mod logs;
 mod metrics;
 mod options;
 use options::Options;
+mod metadata;
 mod router;
 mod time;
 

--- a/src/rust/receiver-mock/src/metadata.rs
+++ b/src/rust/receiver-mock/src/metadata.rs
@@ -1,0 +1,60 @@
+use anyhow::anyhow;
+use std::collections::HashMap;
+
+pub type Metadata = HashMap<String, String>;
+
+/// Parse the value of the X-Sumo-Fields header into a map of field name to field value
+pub fn parse_sumo_fields_header_value(header_value: &str) -> Result<Metadata, anyhow::Error> {
+    let mut field_values = HashMap::new();
+    if header_value.trim().len() == 0 {
+        return Ok(field_values);
+    }
+    for entry in header_value.split(",") {
+        match entry.trim().split_once("=") {
+            Some((field_name, field_value)) => field_values.insert(field_name.to_string(), field_value.to_string()),
+            None => return Err(anyhow!("Failed to parse X-Sumo-Fields, no `=` in {}", entry)),
+        };
+    }
+    return Ok(field_values);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_sumo_fields_valid() {
+        let single_pair = "_collector=test";
+        assert_eq!(
+            parse_sumo_fields_header_value(single_pair).unwrap(),
+            HashMap::from([(String::from("_collector"), String::from("test"))])
+        );
+
+        let multiple_pairs = "service=collection-kube-state-metrics, deployment=collection-kube-state-metrics, node=sumologic-control-plane";
+        assert_eq!(
+            parse_sumo_fields_header_value(multiple_pairs).unwrap(),
+            HashMap::from([
+                (
+                    String::from("service"),
+                    String::from("collection-kube-state-metrics")
+                ),
+                (
+                    String::from("deployment"),
+                    String::from("collection-kube-state-metrics")
+                ),
+                (String::from("node"), String::from("sumologic-control-plane"))
+            ])
+        );
+
+        let empty = "";
+        assert_eq!(parse_sumo_fields_header_value(empty).unwrap(), HashMap::new());
+    }
+
+    #[test]
+    fn test_parse_sumo_fields_invalid() {
+        let invalid_inputs = [",", "no_equals"];
+        for input in invalid_inputs {
+            assert!(parse_sumo_fields_header_value(input).is_err())
+        }
+    }
+}


### PR DESCRIPTION
Store metadata for incoming logs based on the X-Sumo-Fields header value. Allow querying log counts based on using the same interface we have for metrics.