### PR TITLE
feat(receiver-mock): get metadata from X-Sumo-* headers

### DIFF
--- a/src/rust/receiver-mock/src/logs.rs
+++ b/src/rust/receiver-mock/src/logs.rs
@@ -223,7 +223,10 @@ mod tests {
             ])),
         ];
         let body = "{\"log\": \"Log message\", \"timestamp\": 1}";
-        let raw_logs = metadata.iter().map(|mt| (body.to_string(), mt.to_owned())).collect();
+        let raw_logs = metadata
+            .iter()
+            .map(|mt| (body.to_string(), mt.to_owned()))
+            .collect();
         let repository = LogRepository::from_raw_logs(raw_logs).unwrap();
 
         assert_eq!(

--- a/src/rust/receiver-mock/src/main.rs
+++ b/src/rust/receiver-mock/src/main.rs
@@ -145,8 +145,8 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
                     .route(
                         "/collector/heartbeat",
                         web::post().to(router::api::v1::handler_collector_heartbeat),
-                    )
-                )
+                    ),
+            )
             .service(
                 web::scope("/terraform")
                     .app_data(app_metadata.clone())

--- a/src/rust/receiver-mock/src/metadata.rs
+++ b/src/rust/receiver-mock/src/metadata.rs
@@ -1,7 +1,44 @@
+use actix_web::http::header::HeaderMap;
 use anyhow::anyhow;
 use std::collections::HashMap;
 
 pub type Metadata = HashMap<String, String>;
+
+// Get the metadata from Sumo's common http headers
+// This does not include X-Sumo-Fields, which only applies to logs and is handled separately
+pub fn get_common_metadata_from_headers(headers: &HeaderMap) -> Result<Metadata, anyhow::Error> {
+    let mut metadata = Metadata::new();
+
+    // these metadata field names follow what Sumo itself does
+    // see: https://help.sumologic.com/05Search/Get-Started-with-Search/Search-Basics/Built-in-Metadata#built-in-metadata-fields
+    // and: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source/Upload-Data-to-an-HTTP-Source#supported-http-headers
+
+    match headers.get("x-sumo-name") {
+        Some(header_value) => match header_value.to_str() {
+            Ok(header_value_str) => metadata.insert("_sourceName".to_string(), header_value_str.to_string()),
+            Err(_) => return Err(anyhow!("Couldn't parse X-Sumo-Name header value")),
+        },
+        None => None,
+    };
+
+    match headers.get("x-sumo-host") {
+        Some(header_value) => match header_value.to_str() {
+            Ok(header_value_str) => metadata.insert("_sourceHost".to_string(), header_value_str.to_string()),
+            Err(_) => return Err(anyhow!("Couldn't parse X-Sumo-Host header value")),
+        },
+        None => None,
+    };
+
+    match headers.get("x-sumo-category") {
+        Some(header_value) => match header_value.to_str() {
+            Ok(header_value_str) => metadata.insert("_sourceCategory".to_string(), header_value_str.to_string()),
+            Err(_) => return Err(anyhow!("Couldn't parse X-Sumo-Category header value")),
+        },
+        None => None,
+    };
+
+    return Ok(metadata);
+}
 
 /// Parse the value of the X-Sumo-Fields header into a map of field name to field value
 pub fn parse_sumo_fields_header_value(header_value: &str) -> Result<Metadata, anyhow::Error> {
@@ -21,6 +58,7 @@ pub fn parse_sumo_fields_header_value(header_value: &str) -> Result<Metadata, an
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::http::{HeaderName, HeaderValue};
 
     #[test]
     fn test_parse_sumo_fields_valid() {
@@ -55,6 +93,47 @@ mod tests {
         let invalid_inputs = [",", "no_equals"];
         for input in invalid_inputs {
             assert!(parse_sumo_fields_header_value(input).is_err())
+        }
+    }
+
+    #[test]
+    fn test_get_common_metadata_from_headers_valid() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("x-sumo-name"),
+            HeaderValue::from_static("name"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-sumo-host"),
+            HeaderValue::from_static("host"),
+        );
+        headers.insert(
+            HeaderName::from_static("x-sumo-category"),
+            HeaderValue::from_static("category"),
+        );
+        let metadata = get_common_metadata_from_headers(&headers).unwrap();
+
+        assert_eq!(
+            metadata,
+            HashMap::from([
+                (String::from("_sourceName"), String::from("name")),
+                (String::from("_sourceHost"), String::from("host")),
+                (String::from("_sourceCategory"), String::from("category"))
+            ])
+        )
+    }
+    #[test]
+    fn test_get_common_metadata_from_headers_invalid() {
+        let mut headers = HeaderMap::new();
+        let invalid_bytes: [u8; 3] = [255, 255, 255];
+        headers.insert(
+            HeaderName::from_static("x-sumo-name"),
+            HeaderValue::from_bytes(&invalid_bytes).unwrap(),
+        );
+        let result = get_common_metadata_from_headers(&headers);
+        match result {
+            Ok(_) => panic!("Expected error, got valid result"),
+            Err(error) => assert_eq!(error.to_string(), "Couldn't parse X-Sumo-Name header value"),
         }
     }
 }

--- a/src/rust/receiver-mock/src/metrics.rs
+++ b/src/rust/receiver-mock/src/metrics.rs
@@ -375,4 +375,3 @@ myhostname.mem.wired 5680394240 1601909210"
         assert_eq!(*result.metrics_ip_list.get(&ip_address).unwrap(), 9);
     }
 }
-


### PR DESCRIPTION
We only got metadata from X-Sumo-Fields, this commit adds X-Sumo-Name, X-Sumo-Host and X-Sumo-Category. This covers all the headers supported by Sumo's HTTP sources.