### PR TITLE
chore(receiver-mock): migrate from deprecated IntoIter

### DIFF
--- a/src/rust/receiver-mock/src/logs.rs
+++ b/src/rust/receiver-mock/src/logs.rs
@@ -147,7 +147,6 @@ fn get_timestamp_from_body(body: &str) -> Option<u64> {
 mod tests {
     // Note this useful idiom: importing names from outer (for mod tests) scope.
     use super::*;
-    use std::array::IntoIter;
     use std::iter::FromIterator;
     use std::net::{IpAddr, Ipv4Addr};
 
@@ -215,12 +214,15 @@ mod tests {
     #[test]
     fn test_repo_metadata_query() {
         let metadata = [
-            Metadata::from_iter(IntoIter::new([])),
-            Metadata::from_iter(IntoIter::new([("key".to_string(), "value".to_string())])),
-            Metadata::from_iter(IntoIter::new([
-                ("key".to_string(), "valueprime".to_string()),
-                ("key2".to_string(), "value2".to_string()),
-            ])),
+            Metadata::new(),
+            Metadata::from_iter(vec![("key".to_string(), "value".to_string())].into_iter()),
+            Metadata::from_iter(
+                vec![
+                    ("key".to_string(), "valueprime".to_string()),
+                    ("key2".to_string(), "value2".to_string()),
+                ]
+                .into_iter(),
+            ),
         ];
         let body = "{\"log\": \"Log message\", \"timestamp\": 1}";
         let raw_logs = metadata
@@ -230,18 +232,18 @@ mod tests {
         let repository = LogRepository::from_raw_logs(raw_logs).unwrap();
 
         assert_eq!(
-            repository.get_message_count(0, 100, HashMap::from_iter(IntoIter::new([("key", "value")]))),
+            repository.get_message_count(0, 100, HashMap::from_iter(vec![("key", "value")].into_iter())),
             1
         );
         assert_eq!(
-            repository.get_message_count(0, 100, HashMap::from_iter(IntoIter::new([("key", "")]))),
+            repository.get_message_count(0, 100, HashMap::from_iter(vec![("key", "")].into_iter())),
             2
         );
         assert_eq!(
             repository.get_message_count(
                 0,
                 100,
-                HashMap::from_iter(IntoIter::new([("key", "valueprime"), ("key2", "value2")]))
+                HashMap::from_iter(vec![("key", "valueprime"), ("key2", "value2")].into_iter())
             ),
             1
         );

--- a/src/rust/receiver-mock/src/router/mod.rs
+++ b/src/rust/receiver-mock/src/router/mod.rs
@@ -1,4 +1,3 @@
-use std::array::IntoIter;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 use std::net::{IpAddr, Ipv4Addr};
@@ -555,7 +554,7 @@ pub async fn handler_logs_count(
         return HttpResponse::NotImplemented().body("Use the --store-logs flag to enable this endpoint");
     }
     // all_params has all the parameters, so we need to remove the fixed ones
-    let fixed_params: HashSet<&str> = HashSet::from_iter(IntoIter::new(["from_ts", "to_ts"]));
+    let fixed_params: HashSet<&str> = HashSet::from_iter(vec!["from_ts", "to_ts"].into_iter());
     let metadata_params: HashMap<&str, &str> = all_params
         .iter()
         .filter(|(key, _)| !fixed_params.contains(key.as_str()))
@@ -850,7 +849,6 @@ mod tests_metrics {
     use super::*;
     use actix_rt;
     use actix_web::{test, web, App};
-    use std::array::IntoIter;
     use std::iter::FromIterator;
 
     #[actix_rt::test]
@@ -1011,7 +1009,7 @@ mod tests_metrics {
             assert_eq!(
                 result[0].labels,
                 // ref: https://stackoverflow.com/a/27582993
-                HashMap::<String, String>::from_iter(IntoIter::new([
+                HashMap::<String, String>::from_iter(vec![
                     ("mock".to_owned(), "yes".to_owned()),
                     ("group".to_owned(), "events.k8s.io".to_owned()),
                     ("code".to_owned(), "200".to_owned()),
@@ -1019,7 +1017,7 @@ mod tests_metrics {
                     ("cluster".to_owned(), "microk8s".to_owned()),
                     ("component".to_owned(), "apiserver".to_owned()),
                     ("endpoint".to_owned(), "https".to_owned()),
-                ]))
+                ].into_iter())
             );
         }
         {
@@ -1051,7 +1049,7 @@ mod tests_metrics {
             assert_eq!(result[0].timestamp, 1638873379541);
             assert_eq!(
                 result[0].labels,
-                HashMap::<String, String>::from_iter(IntoIter::new([
+                HashMap::<String, String>::from_iter(vec![
                     ("cluster".to_owned(), "microk8s".to_owned()),
                     ("code".to_owned(), "200".to_owned()),
                     ("component".to_owned(), "apiserver".to_owned()),
@@ -1060,7 +1058,7 @@ mod tests_metrics {
                     ("job".to_owned(), "apiserver".to_owned()),
                     ("namespace".to_owned(), "default".to_owned()),
                     ("resource".to_owned(), "events".to_owned()),
-                ]))
+                ].into_iter())
             );
         }
         {
@@ -1080,7 +1078,7 @@ mod tests_metrics {
             assert_eq!(result[0].timestamp, 1638873379541);
             assert_eq!(
                 result[0].labels,
-                HashMap::<String, String>::from_iter(IntoIter::new([
+                HashMap::<String, String>::from_iter(vec![
                     ("cluster".to_owned(), "microk8s".to_owned()),
                     ("code".to_owned(), "200".to_owned()),
                     ("component".to_owned(), "apiserver".to_owned()),
@@ -1089,7 +1087,7 @@ mod tests_metrics {
                     ("job".to_owned(), "apiserver".to_owned()),
                     ("namespace".to_owned(), "default".to_owned()),
                     ("resource".to_owned(), "events".to_owned()),
-                ]))
+                ].into_iter())
             );
         }
         {
@@ -1108,7 +1106,7 @@ mod tests_metrics {
             assert_eq!(result[0].timestamp, 1638873379541);
             assert_eq!(
                 result[0].labels,
-                HashMap::<String, String>::from_iter(IntoIter::new([
+                HashMap::<String, String>::from_iter(vec![
                     ("mock".to_owned(), "yes".to_owned()),
                     ("group".to_owned(), "events.k8s.io".to_owned()),
                     ("code".to_owned(), "200".to_owned()),
@@ -1116,7 +1114,7 @@ mod tests_metrics {
                     ("cluster".to_owned(), "microk8s".to_owned()),
                     ("component".to_owned(), "apiserver".to_owned()),
                     ("endpoint".to_owned(), "https".to_owned()),
-                ]))
+                ].into_iter())
             );
         }
         {


### PR DESCRIPTION
[`IntoIter`](https://doc.rust-lang.org/std/array/struct.IntoIter.html#method.new) got deprecated in rust 1.59 so migrate away from it and use [`std::iter::IntoIterator::into_iter`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html#tymethod.into_iter) instead.

