### PR TITLE
chore(receiver-mock): bump rust edition to 2021

### DIFF
--- a/src/rust/receiver-mock/Cargo.toml
+++ b/src/rust/receiver-mock/Cargo.toml
@@ -2,7 +2,7 @@
 name = "receiver-mock"
 version = "0.1.0"
 authors = ["Sumo Logic <collection@sumologic.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html#migrating-to-2021