### PR TITLE
fix: kubectl pvc describe command changed and uses 'Used By' instead of 'Mounted By' now

### DIFF
--- a/src/commands/pvc-cleaner
+++ b/src/commands/pvc-cleaner
@@ -86,7 +86,7 @@ function check_if_pvc_unmounted() {
   local pvc_name="${1}"
 
   kubectl -n "${NAMESPACE}" describe pvc "${pvc_name}" \
-    | grep "^Mounted By:" \
+    | grep "^Used By:" \
     | grep -q "<none>"
 
   return $?


### PR DESCRIPTION
Current `kubectl describe pvc` output:
```
kubectl -n collection describe pvc file-storage-collection-sumologic-otelcol-logs-9
...
Used By:       collection-sumologic-otelcol-logs-9
```

Old `kubectl describe pvc` output:
```
kubectl -n collection describe pvc file-storage-collection-sumologic-otelcol-logs-9
...
Mounted By:       collection-sumologic-otelcol-logs-9
```