### PR TITLE
feat(receiver-mock): add dump endpoint

### DIFF
--- a/src/rust/receiver-mock/README.md
+++ b/src/rust/receiver-mock/README.md
@@ -126,6 +126,10 @@ The following endpoints provide information about received logs:
   }
   ```
 
+## Dump message
+
+Receiver mock comes with special `/dump` endpoint, which is going to print message on stdout independently on the header value.
+
 ## Disclaimer
 
 This tool is not intended to be used by the 3rd party.

--- a/src/rust/receiver-mock/src/main.rs
+++ b/src/rust/receiver-mock/src/main.rs
@@ -169,6 +169,7 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
                     )
                     .default_service(web::get().to(router::handler_terraform)),
             )
+            .route("/dump", web::post().to(router::handler_dump))
             // Treat every other url as receiver endpoint
             .default_service(web::get().to(router::handler_receiver))
             // Set metrics payload limit to 100MB

--- a/src/rust/receiver-mock/src/router/mod.rs
+++ b/src/rust/receiver-mock/src/router/mod.rs
@@ -577,6 +577,12 @@ pub async fn handler_logs_count(
     HttpResponse::Ok().json(LogsCountResponse { count })
 }
 
+pub async fn handler_dump(body: web::Bytes) -> impl Responder {
+    let string_body = String::from_utf8(body.to_vec()).unwrap();
+    println!("dump: {}", string_body);
+    HttpResponse::Ok().body("")
+}
+
 pub fn print_request_headers(
     method: &http::Method,
     version: http::Version,


### PR DESCRIPTION
add endpoint which just dumps requests (to test e.g. collectd plugin)