### PR TITLE
chore(github actions): fix ci by using external git command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux \
         -o customer-trace-tester cmd/customer-trace-tester/main.go
 
 FROM rust:1.57.0-alpine3.13 as rust-builder
-RUN apk update && apk upgrade && apk add g++
+RUN apk update && apk upgrade && apk add g++ git
 
 WORKDIR /receiver-mock
 COPY ./src/rust/receiver-mock .

--- a/src/rust/receiver-mock/.cargo/config.toml
+++ b/src/rust/receiver-mock/.cargo/config.toml
@@ -1,0 +1,4 @@
+[net]
+# use the `git` executable for git operations due to failing github actions
+# ref: https://users.rust-lang.org/t/cargo-uses-too-much-memory-being-run-in-qemu/76531
+git-fetch-with-cli = true


### PR DESCRIPTION
After some investigation and tries, it comes out that the issue is result of using cargo buil-in git command along with Qemu:

See https://users.rust-lang.org/t/cargo-uses-too-much-memory-being-run-in-qemu/76531
for reference