### PR TITLE
chore: update formatting options

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -24,6 +24,9 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
+      - name: Check receiver-mock formatting
+        working-directory: src/rust/receiver-mock/
+        run: make check-rustfmt
       - name: Test receiver-mock
         working-directory: src/rust/receiver-mock/
         run: make test

--- a/src/rust/receiver-mock/Cargo.toml
+++ b/src/rust/receiver-mock/Cargo.toml
@@ -14,7 +14,7 @@ actix-rt = "2"
 anyhow = "1.0.58"
 bytes = "1"
 base64 = "0.13"
-serde = { version ="1.0.140" , features = ["derive"] }
+serde = { version = "1.0.140", features = ["derive"] }
 serde_json = "1.0.82"
 clap = "2.34.0"
 timer = "0.2"

--- a/src/rust/receiver-mock/Makefile
+++ b/src/rust/receiver-mock/Makefile
@@ -1,4 +1,4 @@
-RUSTFMT_FLAGS = --config-path ../.rustfmt.toml --edition 2018
+RUSTFMT_FLAGS = --config-path ../.rustfmt.toml --edition 2021
 RUST_SOURCE_FILES = $(shell find . -name "*.rs" -not -path "./target/*")
 
 .PHONY: rustfmt

--- a/src/rust/receiver-mock/src/main.rs
+++ b/src/rust/receiver-mock/src/main.rs
@@ -4,7 +4,7 @@ extern crate json_str;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use actix_web::{web};
+use actix_web::web;
 
 use chrono::Duration;
 use clap::{value_t, App, Arg};
@@ -131,12 +131,12 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
             .wrap_fn(move |req, srv| {
                 if opts.print.headers {
                     let headers = req.headers();
-                    
+
                     router::print_request_headers(req.method(), req.version(), req.uri(), headers);
                 }
 
                 thread::sleep(opts.delay_time);
-                
+
                 actix_web::dev::Service::call(&srv, req)
             })
             .app_data(app_state.clone()) // Mutable shared state

--- a/src/rust/receiver-mock/src/router/api.rs
+++ b/src/rust/receiver-mock/src/router/api.rs
@@ -69,14 +69,12 @@ mod tests_api {
             store_logs: false,
         };
 
-        let mut app = test::init_service(
-            App::new()
-                .app_data(web::Data::new(opts.clone()))
-                .service(web::scope("/api/v1").route(
-                    "/collector/register",
-                    web::post().to(router::api::v1::handler_collector_register),
-                )),
-        )
+        let mut app = test::init_service(App::new().app_data(web::Data::new(opts.clone())).service(
+            web::scope("/api/v1").route(
+                "/collector/register",
+                web::post().to(router::api::v1::handler_collector_register),
+            ),
+        ))
         .await;
 
         {

--- a/src/rust/receiver-mock/src/router/mod.rs
+++ b/src/rust/receiver-mock/src/router/mod.rs
@@ -1010,7 +1010,7 @@ mod tests_metrics {
             let resp = test::call_service(&mut app, req).await;
             assert_eq!(resp.status(), 200);
 
-            let body= test::read_body(resp).await;
+            let body = test::read_body(resp).await;
             assert_eq!(body, web::Bytes::from_static(b""));
         }
         {
@@ -1027,15 +1027,18 @@ mod tests_metrics {
             assert_eq!(
                 result[0].labels,
                 // ref: https://stackoverflow.com/a/27582993
-                HashMap::<String, String>::from_iter(vec![
-                    ("mock".to_owned(), "yes".to_owned()),
-                    ("group".to_owned(), "events.k8s.io".to_owned()),
-                    ("code".to_owned(), "200".to_owned()),
-                    ("job".to_owned(), "apiserver".to_owned()),
-                    ("cluster".to_owned(), "microk8s".to_owned()),
-                    ("component".to_owned(), "apiserver".to_owned()),
-                    ("endpoint".to_owned(), "https".to_owned()),
-                ].into_iter())
+                HashMap::<String, String>::from_iter(
+                    vec![
+                        ("mock".to_owned(), "yes".to_owned()),
+                        ("group".to_owned(), "events.k8s.io".to_owned()),
+                        ("code".to_owned(), "200".to_owned()),
+                        ("job".to_owned(), "apiserver".to_owned()),
+                        ("cluster".to_owned(), "microk8s".to_owned()),
+                        ("component".to_owned(), "apiserver".to_owned()),
+                        ("endpoint".to_owned(), "https".to_owned()),
+                    ]
+                    .into_iter()
+                )
             );
         }
         {
@@ -1067,16 +1070,19 @@ mod tests_metrics {
             assert_eq!(result[0].timestamp, 1638873379541);
             assert_eq!(
                 result[0].labels,
-                HashMap::<String, String>::from_iter(vec![
-                    ("cluster".to_owned(), "microk8s".to_owned()),
-                    ("code".to_owned(), "200".to_owned()),
-                    ("component".to_owned(), "apiserver".to_owned()),
-                    ("endpoint".to_owned(), "https".to_owned()),
-                    ("group".to_owned(), "events.k8s.io".to_owned()),
-                    ("job".to_owned(), "apiserver".to_owned()),
-                    ("namespace".to_owned(), "default".to_owned()),
-                    ("resource".to_owned(), "events".to_owned()),
-                ].into_iter())
+                HashMap::<String, String>::from_iter(
+                    vec![
+                        ("cluster".to_owned(), "microk8s".to_owned()),
+                        ("code".to_owned(), "200".to_owned()),
+                        ("component".to_owned(), "apiserver".to_owned()),
+                        ("endpoint".to_owned(), "https".to_owned()),
+                        ("group".to_owned(), "events.k8s.io".to_owned()),
+                        ("job".to_owned(), "apiserver".to_owned()),
+                        ("namespace".to_owned(), "default".to_owned()),
+                        ("resource".to_owned(), "events".to_owned()),
+                    ]
+                    .into_iter()
+                )
             );
         }
         {
@@ -1096,16 +1102,19 @@ mod tests_metrics {
             assert_eq!(result[0].timestamp, 1638873379541);
             assert_eq!(
                 result[0].labels,
-                HashMap::<String, String>::from_iter(vec![
-                    ("cluster".to_owned(), "microk8s".to_owned()),
-                    ("code".to_owned(), "200".to_owned()),
-                    ("component".to_owned(), "apiserver".to_owned()),
-                    ("endpoint".to_owned(), "https".to_owned()),
-                    ("group".to_owned(), "events.k8s.io".to_owned()),
-                    ("job".to_owned(), "apiserver".to_owned()),
-                    ("namespace".to_owned(), "default".to_owned()),
-                    ("resource".to_owned(), "events".to_owned()),
-                ].into_iter())
+                HashMap::<String, String>::from_iter(
+                    vec![
+                        ("cluster".to_owned(), "microk8s".to_owned()),
+                        ("code".to_owned(), "200".to_owned()),
+                        ("component".to_owned(), "apiserver".to_owned()),
+                        ("endpoint".to_owned(), "https".to_owned()),
+                        ("group".to_owned(), "events.k8s.io".to_owned()),
+                        ("job".to_owned(), "apiserver".to_owned()),
+                        ("namespace".to_owned(), "default".to_owned()),
+                        ("resource".to_owned(), "events".to_owned()),
+                    ]
+                    .into_iter()
+                )
             );
         }
         {
@@ -1124,15 +1133,18 @@ mod tests_metrics {
             assert_eq!(result[0].timestamp, 1638873379541);
             assert_eq!(
                 result[0].labels,
-                HashMap::<String, String>::from_iter(vec![
-                    ("mock".to_owned(), "yes".to_owned()),
-                    ("group".to_owned(), "events.k8s.io".to_owned()),
-                    ("code".to_owned(), "200".to_owned()),
-                    ("job".to_owned(), "apiserver".to_owned()),
-                    ("cluster".to_owned(), "microk8s".to_owned()),
-                    ("component".to_owned(), "apiserver".to_owned()),
-                    ("endpoint".to_owned(), "https".to_owned()),
-                ].into_iter())
+                HashMap::<String, String>::from_iter(
+                    vec![
+                        ("mock".to_owned(), "yes".to_owned()),
+                        ("group".to_owned(), "events.k8s.io".to_owned()),
+                        ("code".to_owned(), "200".to_owned()),
+                        ("job".to_owned(), "apiserver".to_owned()),
+                        ("cluster".to_owned(), "microk8s".to_owned()),
+                        ("component".to_owned(), "apiserver".to_owned()),
+                        ("endpoint".to_owned(), "https".to_owned()),
+                    ]
+                    .into_iter()
+                )
             );
         }
         {
@@ -1219,8 +1231,11 @@ mod tests_logs {
             let resp = test::call_service(&mut app, req).await;
             assert_eq!(resp.status(), 400);
 
-            let body= test::read_body(resp).await;
-            assert_eq!(body, web::Bytes::from_static(b"Unable to parse X-Sumo-Fields header value"));
+            let body = test::read_body(resp).await;
+            assert_eq!(
+                body,
+                web::Bytes::from_static(b"Unable to parse X-Sumo-Fields header value")
+            );
         }
 
         // add logs with metadata


### PR DESCRIPTION
This PR updates `rustfmt` edition used in `Makefile` to 2021 (since the project is also set to that edition), formats the code using this updated `make` rule and adds a formatting check to the workflows.