### PR TITLE
feat(Dockerfile): install cmake on the build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,11 @@ RUN CGO_ENABLED=0 GOOS=linux \
         -o customer-trace-tester cmd/customer-trace-tester/main.go
 
 FROM rust:1.57.0-alpine3.13 as rust-builder
-RUN apk update && apk upgrade && apk add g++ git
+RUN apk update \
+    && apk upgrade \
+    && apk add g++ git \
+# Cmake and make are needed to build proto-build Rust dependency.
+    && apk add cmake make
 
 WORKDIR /receiver-mock
 COPY ./src/rust/receiver-mock .


### PR DESCRIPTION
After adding a support for otlp logs in the receiver mock, some checks did not pass because one of the newly added dependencies needed cmake to build ([ref](https://github.com/SumoLogic/sumologic-kubernetes-tools/actions/runs/2790052818)) and the build failed on the Docker image.