### PR TITLE
feat(receiver-mock): change printing to logging

### DIFF
--- a/src/rust/receiver-mock/Cargo.lock
+++ b/src/rust/receiver-mock/Cargo.lock
@@ -468,6 +468,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "opentelemetry"
@@ -1389,12 +1400,14 @@ dependencies = [
  "http",
  "itertools",
  "json_str",
+ "log",
  "opentelemetry-proto",
  "prometheus-parse",
  "prost",
  "rand",
  "serde",
  "serde_json",
+ "simple_logger",
  "timer",
 ]
 
@@ -1521,6 +1534,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simple_logger"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48047e77b528151aaf841a10a9025f9459da80ba820e425ff7eb005708a76dc7"
+dependencies = [
+ "atty",
+ "colored",
+ "log",
+ "time 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1827,9 +1853,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "log",
@@ -1851,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
 ]

--- a/src/rust/receiver-mock/Cargo.toml
+++ b/src/rust/receiver-mock/Cargo.toml
@@ -26,3 +26,5 @@ http = "0.2"
 opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust", features = ["gen-tonic", "build-server", "logs", "metrics"] }
 prost = "0.10.4"
 itertools = "0.10.3"
+log = "0.4.17"
+simple_logger = "2.3.0"

--- a/src/rust/receiver-mock/src/logs/mod.rs
+++ b/src/rust/receiver-mock/src/logs/mod.rs
@@ -1,4 +1,5 @@
 use crate::time;
+use log::warn;
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::net::IpAddr;
@@ -87,7 +88,7 @@ impl LogRepository {
         let timestamp = match get_timestamp_from_body(&body) {
             Some(ts) => ts,
             None => {
-                eprintln!("Couldn't find timestamp in log line {}", body);
+                warn!("Couldn't find timestamp in log line {}", body);
                 time::get_now_ms() // use current system time if no timestamp found
             }
         };

--- a/src/rust/receiver-mock/src/main.rs
+++ b/src/rust/receiver-mock/src/main.rs
@@ -8,6 +8,8 @@ use actix_web::web;
 
 use chrono::Duration;
 use clap::{value_t, App, Arg};
+use log::error;
+use log::info;
 use std::thread;
 use std::time as stime;
 
@@ -21,6 +23,8 @@ mod time;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    simple_logger::init_with_level(log::Level::Debug).unwrap();
+
     let matches = App::new("Receiver mock")
       .version("0.0")
       .author("Sumo Logic <collection@sumologic.com>")
@@ -122,7 +126,7 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
         fields: Mutex::new(HashMap::new()),
     });
 
-    println!("Receiver mock is waiting for enemy on 0.0.0.0:{}!", port);
+    info!("Receiver mock is waiting for enemy on 0.0.0.0:{}!", port);
     let result = actix_web::HttpServer::new(move || {
         actix_web::App::new()
             // Middleware printing headers for all handlers.
@@ -217,7 +221,7 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
     match result {
         Ok(result) => Ok(result),
         Err(e) => {
-            eprintln!("server error: {}", e);
+            error!("server error: {}", e);
             Err(e)
         }
     }

--- a/src/rust/receiver-mock/src/metrics/mod.rs
+++ b/src/rust/receiver-mock/src/metrics/mod.rs
@@ -1,3 +1,4 @@
+use log::debug;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::net::IpAddr;
@@ -44,7 +45,7 @@ pub fn handle_carbon2(lines: std::str::Lines, address: IpAddr, print_opts: optio
 
     for line in lines {
         if print_opts.metrics {
-            println!("metric => {}", line);
+            debug!("metric => {}", line);
         }
         let mut split = line.split("  ");
         let intrinsic_metrics = split.nth(0).unwrap();
@@ -72,17 +73,17 @@ pub fn handle_graphite(lines: std::str::Lines, address: IpAddr, print_opts: opti
 
     for line in lines {
         if print_opts.metrics {
-            println!("metric => {}", line);
+            debug!("metric => {}", line);
         }
         let split_line = line.split(' ').collect::<Vec<_>>();
         if split_line.len() != 3 {
-            println!("Incorrect graphite metric line: {}", line);
+            debug!("Incorrect graphite metric line: {}", line);
             continue;
         }
 
         let split_metric = split_line[0].split('.').collect::<Vec<_>>();
         if split_metric.len() != 3 {
-            println!("Incorrect graphite metric name: {}", split_line[0]);
+            debug!("Incorrect graphite metric name: {}", split_line[0]);
             continue;
         }
 
@@ -107,7 +108,7 @@ pub fn handle_prometheus(lines: std::str::Lines, address: IpAddr, opts: &options
         }
 
         if opts.print.metrics {
-            println!("metric => {}", l);
+            debug!("metric => {}", l);
         }
         // This should also be implemented in terms of parsed metrics, see below.
         let metric_name = l.split("{").nth(0).unwrap().to_string();

--- a/src/rust/receiver-mock/src/router/otlp.rs
+++ b/src/rust/receiver-mock/src/router/otlp.rs
@@ -7,6 +7,8 @@ use crate::metrics::MetricsHandleResult;
 use crate::options;
 use crate::router::*;
 use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use log::debug;
+use log::warn;
 use opentelemetry_proto::tonic::common::v1 as commonv1;
 use opentelemetry_proto::tonic::logs::v1 as logsv1;
 use opentelemetry_proto::tonic::metrics::v1 as metricsv1;
@@ -51,7 +53,7 @@ pub async fn handler_receiver_otlp_logs(
 
                 if opts.print.logs {
                     for line in lines {
-                        println!("log => {}", line);
+                        debug!("log => {}", line);
                     }
                 }
             }
@@ -138,7 +140,7 @@ pub async fn handler_receiver_otlp_metrics(
             for resource_metrics in metrics_data.resource_metrics {
                 if resource_metrics.resource.is_none() {
                     // TODO: Replace printing with logging
-                    println!("WARN: resource is none for resource metrics");
+                    warn!("resource is none for resource metrics");
                     continue;
                 }
 
@@ -147,9 +149,9 @@ pub async fn handler_receiver_otlp_metrics(
                     for metric in instrumentation_lib_metrics.metrics {
                         let metric_sample_vec = sample::otlp_metric_to_samples(&metric, resource_attributes);
 
-                        for m in &metric_sample_vec {
-                            if opts.print.metrics {
-                                println!("metrics => {:?}", m);
+                        if opts.print.metrics {
+                            for m in &metric_sample_vec {
+                                debug!("metrics => {:?}", m);
                             }
                         }
                         if opts.store_metrics {


### PR DESCRIPTION
Resolves #34 
Printing with println and eprintln macros has been replaced with calls to macros from the `log` crate. A `simple_logger` has been used to log.

Please note that this change also causes dependencies to print logs (see the example output below). Due to that, please check if the log levels I assigned to each message are ok.

Technically, all logging calls can be replaced in the future with macros from the `tracing` crate, since they have the same API. I don't think that tracing would be particularly useful in this mock though.

Example output:
```
2022-08-24T11:15:39.236Z INFO [receiver_mock] Receiver mock is waiting for enemy on 0.0.0.0:3000!
2022-08-24T11:15:39.238Z INFO [actix_server::builder] Starting 8 workers
2022-08-24T11:15:39.238Z INFO [actix_server::server] Actix runtime found; starting in Actix runtime
2022-08-24T11:15:42.235Z DEBUG [receiver_mock::router] log => WARNING:sumotest:DENY NO 0
2022-08-24T11:15:42.235Z DEBUG [receiver_mock::router] log => WARNING:sumotest:DENY NO 1
2022-08-24T11:15:42.235Z DEBUG [receiver_mock::router] log => WARNING:sumotest:DENY NO 2
2022-08-24T11:15:42.235Z DEBUG [receiver_mock::router] log => WARNING:sumotest:DENY NO 3
2022-08-24T11:15:42.235Z DEBUG [receiver_mock::router] log => WARNING:sumotest:DENY NO 4
```