### PR TITLE
feat(receiver-mock): add handler for otlp traces

### DIFF
--- a/src/rust/receiver-mock/Cargo.toml
+++ b/src/rust/receiver-mock/Cargo.toml
@@ -23,7 +23,7 @@ json_str = "*"
 rand = "0.8"
 prometheus-parse = { git = "https://github.com/ccakes/prometheus-parse-rs", rev = "a4574e9bade29b8af31e68b68a5392c61cbb74cd" }
 http = "0.2"
-opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust", features = ["gen-tonic", "build-server", "logs", "metrics"] }
+opentelemetry-proto = { git = "https://github.com/open-telemetry/opentelemetry-rust", features = ["gen-tonic", "build-server", "logs", "metrics", "traces"] }
 prost = "0.10.4"
 itertools = "0.10.3"
 log = "0.4.17"

--- a/src/rust/receiver-mock/src/main.rs
+++ b/src/rust/receiver-mock/src/main.rs
@@ -207,6 +207,10 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
                     .route(
                         "/metrics",
                         web::post().to(router::otlp::handler_receiver_otlp_metrics),
+                    )
+                    .route(
+                        "/traces",
+                        web::post().to(router::otlp::handler_receiver_otlp_traces),
                     ),
             )
             // Treat every other url as receiver endpoint


### PR DESCRIPTION
A simple handler that counts received spans has been added. 