### PR TITLE
chore: fix .gitignore

### DIFF
--- a/src/go/.gitignore
+++ b/src/go/.gitignore
@@ -1,4 +1,5 @@
-stress-tester
-k8s-api-test
-customer-trace-tester
-update-collection-v3
+# Ignore the binaries created in this directory by `make build`.
+/customer-trace-tester
+/k8s-api-test
+/stress-tester
+/update-collection-v3

--- a/src/go/cmd/update-collection-v3/.gitignore
+++ b/src/go/cmd/update-collection-v3/.gitignore
@@ -1,1 +1,2 @@
-update-collection-v3
+# Ignore the binary created by `make build`.
+/update-collection-v3


### PR DESCRIPTION
The previous version caused any files added in e.g. customer-trace-tester directory to be ignored.