### PR TITLE
ci: install protoc during workflow and while building image

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
       - name: Build receiver-mock
         working-directory: src/rust/receiver-mock/
         run: cargo rustc -- -D warnings

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN apk update \
     && apk upgrade \
     && apk add g++ git \
 # Cmake and make are needed to build proto-build Rust dependency.
-    && apk add cmake make
+    && apk add cmake make \
+# Protoc is needed to build opentelemetry-proto Rust dependency. 
+    && apk add protoc
 
 WORKDIR /receiver-mock
 COPY ./src/rust/receiver-mock .


### PR DESCRIPTION
The CI in #329 did not work, because `tonic` (used to build `opentelemetry-proto`) no longer introduces `protoc` binary. This PR adds installation steps of `protoc` to our workflows.
The installation step was taken from here: https://github.com/marketplace/actions/setup-protoc
A related issue in the upstream: https://github.com/open-telemetry/opentelemetry-rust/issues/873