### PR TITLE
feat(update-collection-v3): add warning for special values with 'replace' suffix in configuration

### DIFF
--- a/src/go/cmd/update-collection-v3/main.go
+++ b/src/go/cmd/update-collection-v3/main.go
@@ -10,6 +10,7 @@ import (
 	disablethanos "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/disable-thanos"
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/events"
 	kubestatemetricscollectors "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/kube-state-metrics-collectors"
+	tracingreplaces "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/tracing-replaces"
 )
 
 var (
@@ -55,6 +56,7 @@ var migrationDirectoriesAndFunctions = map[string]migrateFunc{
 	"kube-prometheus-stack": kubestatemetricscollectors.Migrate,
 	"events":                events.Migrate,
 	"disable-thanos":        disablethanos.Migrate,
+	"tracing-replaces":      tracingreplaces.Migrate,
 }
 
 func migrateYaml(input string) (string, error) {

--- a/src/go/cmd/update-collection-v3/migrations/tracing-replaces/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/tracing-replaces/migrate.go
@@ -1,0 +1,101 @@
+package tracingreplaces
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var otelagentReplaces []string = []string{
+	"exporters.otlpmetrics.endpoint.replace",
+	"exporters.otlptraces.endpoint.replace",
+}
+
+var otelcolReplaces []string = []string{
+	"processors.source.collector.replace",
+	"processors.source.name.replace",
+	"processors.source.category.replace",
+	"processors.source.category_prefix.replace",
+	"processors.source.category_replace_dash.replace",
+	"processors.source.exclude_namespace_regex.replace",
+	"processors.source.exclude_pod_regex.replace",
+	"processors.source.exclude_container_regex.replace",
+	"processors.source.exclude_host_regex.replace",
+	"processors.resource.cluster.replace",
+	"exporters.sumologic.source_name.replace",
+	"exporters.sumologic.source_category.replace",
+}
+
+func Migrate(yamlV2 string) (yamlV3 string, err error) {
+	valuesV2, err := parseValues(yamlV2)
+	if err != nil {
+		return "", fmt.Errorf("error parsing input yaml: %v", err)
+	}
+
+	if valuesV2.Otelagent != nil {
+		foundOtelagentReplaces := []string{}
+		foundOtelagentReplaces, err = findUsedReplaces(valuesV2.Otelagent.Config, otelagentReplaces)
+		if err != nil {
+			return "", fmt.Errorf("error parsing otelcol configuration: %v", err)
+		}
+
+		if len(foundOtelagentReplaces) != 0 {
+			fmt.Println("WARNING! Found following special values in otelagent configuration which must be manually migrated:")
+			fmt.Println(strings.Join(foundOtelagentReplaces, "\n"))
+			fmt.Println("for details please see documentation: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/v3-migration-doc.md")
+		}
+	}
+
+	if valuesV2.Otelcol != nil {
+		foundOtelcolReplaces := []string{}
+		foundOtelcolReplaces, err = findUsedReplaces(valuesV2.Otelcol.Config, otelcolReplaces)
+		if err != nil {
+			return "", fmt.Errorf("error parsing otelcol configuration: %v", err)
+		}
+		if len(foundOtelcolReplaces) != 0 {
+			fmt.Println("WARNING! Found following special values in otelcol configuration which must be manually migrated:")
+			fmt.Println(strings.Join(foundOtelcolReplaces, "\n"))
+			fmt.Println("for details please see documentation: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/v3-migration-doc.md")
+		}
+	}
+
+	return yamlV2, err
+}
+
+func parseValues(yamlV2 string) (ValuesV2, error) {
+	var valuesV2 ValuesV2
+	err := yaml.Unmarshal([]byte(yamlV2), &valuesV2)
+	return valuesV2, err
+}
+
+func parseConfigToString(config map[string]interface{}) (string, error) {
+	buffer := bytes.Buffer{}
+	encoder := yaml.NewEncoder(&buffer)
+	encoder.SetIndent(2)
+	err := encoder.Encode(config)
+	if err != nil {
+		return "", err
+	}
+	return buffer.String(), err
+}
+
+func findUsedReplaces(config map[string]interface{}, replaces []string) ([]string, error) {
+	if config == nil {
+		return []string{}, nil
+	}
+
+	confStr, err := parseConfigToString(config)
+	if err != nil {
+		return []string{}, err
+	}
+
+	found := []string{}
+	for _, r := range replaces {
+		if strings.Contains(confStr, r) {
+			found = append(found, fmt.Sprintf(" - %s", r))
+		}
+	}
+	return found, nil
+}

--- a/src/go/cmd/update-collection-v3/migrations/tracing-replaces/values2.go
+++ b/src/go/cmd/update-collection-v3/migrations/tracing-replaces/values2.go
@@ -1,0 +1,16 @@
+package tracingreplaces
+
+type ValuesV2 struct {
+	Otelagent *Otelagent `yaml:"otelagent,omitempty"`
+	Otelcol   *Otelcol   `yaml:"otelcol,omitempty"`
+}
+
+type Otelagent struct {
+	Config map[string]interface{} `yaml:"config,omitempty"`
+	Rest   map[string]interface{} `yaml:",inline"`
+}
+
+type Otelcol struct {
+	Config map[string]interface{} `yaml:"config,omitempty"`
+	Rest   map[string]interface{} `yaml:",inline"`
+}

--- a/src/go/cmd/update-collection-v3/testdata/tracing-replaces.input.yaml
+++ b/src/go/cmd/update-collection-v3/testdata/tracing-replaces.input.yaml
@@ -1,0 +1,30 @@
+otelagent:
+  config:
+    exporters:
+      otlphttp/metrics:
+        endpoint: http://exporters.otlpmetrics.endpoint.replace:4318
+      otlphttp/traces:
+        endpoint: http://exporters.otlptraces.endpoint.replace:4318
+otelcol:
+  config:
+    exporters:
+      sumologic:
+        source_category: exporters.sumologic.source_category.replace
+        source_name: exporters.sumologic.source_name.replace
+    processors:
+      source:
+        annotation_prefix: k8s.pod.annotation.
+        collector: processors.source.collector.replace
+        exclude:
+          k8s.container.name: processors.source.exclude_container_regex.replace
+          k8s.host.name: processors.source.exclude_host_regex.replace
+          k8s.namespace.name: processors.source.exclude_namespace_regex.replace
+          k8s.pod.name: processors.source.exclude_pod_regex.replace
+        pod_key: k8s.pod.name
+        pod_name_key: k8s.pod.pod_name
+        pod_template_hash_key: k8s.pod.label.pod-template-hash
+        source_category: processors.source.category.replace
+        source_category_prefix: processors.source.category_prefix.replace
+        source_category_replace_dash: processors.source.category_replace_dash.replace
+        source_host: '%{k8s.pod.hostname}'
+        source_name: processors.source.name.replace

--- a/src/go/cmd/update-collection-v3/testdata/tracing-replaces.output.yaml
+++ b/src/go/cmd/update-collection-v3/testdata/tracing-replaces.output.yaml
@@ -1,0 +1,30 @@
+otelagent:
+  config:
+    exporters:
+      otlphttp/metrics:
+        endpoint: http://exporters.otlpmetrics.endpoint.replace:4318
+      otlphttp/traces:
+        endpoint: http://exporters.otlptraces.endpoint.replace:4318
+otelcol:
+  config:
+    exporters:
+      sumologic:
+        source_category: exporters.sumologic.source_category.replace
+        source_name: exporters.sumologic.source_name.replace
+    processors:
+      source:
+        annotation_prefix: k8s.pod.annotation.
+        collector: processors.source.collector.replace
+        exclude:
+          k8s.container.name: processors.source.exclude_container_regex.replace
+          k8s.host.name: processors.source.exclude_host_regex.replace
+          k8s.namespace.name: processors.source.exclude_namespace_regex.replace
+          k8s.pod.name: processors.source.exclude_pod_regex.replace
+        pod_key: k8s.pod.name
+        pod_name_key: k8s.pod.pod_name
+        pod_template_hash_key: k8s.pod.label.pod-template-hash
+        source_category: processors.source.category.replace
+        source_category_prefix: processors.source.category_prefix.replace
+        source_category_replace_dash: processors.source.category_replace_dash.replace
+        source_host: '%{k8s.pod.hostname}'
+        source_name: processors.source.name.replace


### PR DESCRIPTION
feat(update-collection-v3): add warning for special values with 'replace' suffix in configuration for otelcol and otelagent

related to https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/2615

User will see following warning when special values with replace suffix are available in the configuration for otelcol and otelagent:
```
./update-collection-v3 --in values.input.yaml
WARNING! Found following special values in otelagent configuration which must be manually migrated:
 - exporters.otlpmetrics.endpoint.replace
 - exporters.otlptraces.endpoint.replace
for details please see documentation: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/docs/v3_migration_doc.md
WARNING! Found following special values in otelcol configuration which must be manually migrated:
 - processors.source.collector.replace
 - processors.source.name.replace
 - processors.source.category.replace
 - processors.source.category_prefix.replace
 - processors.source.category_replace_dash.replace
 - processors.source.exclude_namespace_regex.replace
 - processors.source.exclude_pod_regex.replace
 - processors.source.exclude_container_regex.replace
 - processors.source.exclude_host_regex.replace
 - exporters.sumologic.source_name.replace
 - exporters.sumologic.source_category.replace
for details please see documentation: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/docs/v3_migration_doc.md
2022/11/22 12:27:27 Successfully migrated the configuration
```