### PR TITLE
feat(update-collection-v3): add migration for FluentD autoscaling

### DIFF
--- a/src/go/cmd/update-collection-v3/main.go
+++ b/src/go/cmd/update-collection-v3/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/events"
 	eventsconfigmerge "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/events-config-merge"
 	falcoupgrade "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/falco-upgrade"
+	fluentdautoscaling "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/fluentd-autoscaling"
 	fluentdlogsconfigs "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/fluentd-logs-configs"
 	kubeprometheusstackrepository "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/kube-prometheus-stack-repository"
 	kubestatemetricscollectors "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/kube-state-metrics-collectors"
@@ -21,9 +22,9 @@ import (
 	otellogsconfigmerge "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/otellogs-config-merge"
 	removeloadconfigfile "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/remove-load-config-file"
 	tailingsidecaroperatorupgrade "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/tailing-sidecar-operator-upgrade"
-	tracingreplaces "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/tracing-replaces"
 	tracingconfig "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/tracing-config"
 	tracingobjectchanges "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/tracing-objects-changes"
+	tracingreplaces "github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/tracing-replaces"
 	"gopkg.in/yaml.v3"
 )
 
@@ -130,11 +131,15 @@ var migrations = []Migration{
 	},
 	{
 		directory: "tracing-objects-changes",
-		action: tracingobjectchanges.Migrate,
+		action:    tracingobjectchanges.Migrate,
 	},
 	{
 		directory: "tracing-config",
 		action:    tracingconfig.Migrate,
+	},
+	{
+		directory: "fluentd-autoscaling",
+		action:    fluentdautoscaling.Migrate,
 	},
 }
 

--- a/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/common.go
+++ b/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/common.go
@@ -1,0 +1,32 @@
+package fluentdautoscaling
+
+type Fluentd struct {
+	Logs    *FluentdLogs           `yaml:"logs,omitempty"`
+	Metrics *FluentdMetrics        `yaml:"metrics,omitempty"`
+	Rest    map[string]interface{} `yaml:",inline"`
+}
+
+type FluentdLogs struct {
+	Autoscaling *Autoscaling           `yaml:"autoscaling,omitempty"`
+	Rest        map[string]interface{} `yaml:",inline"`
+}
+
+type FluentdMetrics = FluentdLogs
+
+type Metadata struct {
+	Logs    *MetadataLogs          `yaml:"logs,omitempty"`
+	Metrics *MetadataMetrics       `yaml:"metrics,omitempty"`
+	Rest    map[string]interface{} `yaml:",inline"`
+}
+
+type MetadataLogs struct {
+	Autoscaling *Autoscaling           `yaml:"autoscaling,omitempty"`
+	Rest        map[string]interface{} `yaml:",inline"`
+}
+
+type MetadataMetrics = MetadataLogs
+
+type Autoscaling struct {
+	Enabled *bool                  `yaml:"enabled,omitempty"`
+	Rest    map[string]interface{} `yaml:",inline"`
+}

--- a/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/migrate.go
@@ -1,0 +1,99 @@
+package fluentdautoscaling
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Migrate(input string) (string, error) {
+	valuesInput, err := parseValues(input)
+	if err != nil {
+		return "", fmt.Errorf("error parsing input yaml: %v", err)
+	}
+
+	valuesOutput := migrate(&valuesInput)
+
+	buffer := bytes.Buffer{}
+	encoder := yaml.NewEncoder(&buffer)
+	encoder.SetIndent(2)
+	err = encoder.Encode(valuesOutput)
+	return buffer.String(), err
+}
+
+func parseValues(input string) (ValuesInput, error) {
+	var valuesInput ValuesInput
+	err := yaml.Unmarshal([]byte(input), &valuesInput)
+	return valuesInput, err
+}
+
+func migrate(valuesInput *ValuesInput) ValuesOutput {
+	valuesOutput := ValuesOutput{
+		Rest:     valuesInput.Rest,
+		Fluentd:  valuesInput.Fluentd,
+		Metadata: valuesInput.Metadata,
+	}
+
+	// we only do something if autoscaling is set for either FluentD logs or metrics
+	if valuesInput.Fluentd == nil {
+		return valuesOutput
+	}
+
+	migrateMetricsAutoscaling(valuesInput, &valuesOutput)
+	migrateLogsAutoscaling(valuesInput, &valuesOutput)
+
+	return valuesOutput
+}
+
+func migrateMetricsAutoscaling(valuesInput *ValuesInput, valuesOutput *ValuesOutput) {
+	if valuesInput.Fluentd.Metrics == nil ||
+		valuesInput.Fluentd.Metrics.Autoscaling == nil ||
+		valuesInput.Fluentd.Metrics.Autoscaling.Enabled == nil ||
+		!*valuesInput.Fluentd.Metrics.Autoscaling.Enabled {
+		return
+	}
+
+	if valuesOutput.Metadata == nil {
+		valuesOutput.Metadata = &Metadata{}
+	}
+
+	if valuesOutput.Metadata.Metrics == nil {
+		valuesOutput.Metadata.Metrics = &MetadataMetrics{}
+	}
+
+	if valuesOutput.Metadata.Metrics.Autoscaling == nil {
+		valuesOutput.Metadata.Metrics.Autoscaling = &Autoscaling{}
+	}
+
+	if valuesOutput.Metadata.Metrics.Autoscaling.Enabled == nil {
+		valuesOutput.Metadata.Metrics.Autoscaling.Enabled = new(bool)
+		*valuesOutput.Metadata.Metrics.Autoscaling.Enabled = true
+	}
+}
+
+func migrateLogsAutoscaling(valuesInput *ValuesInput, valuesOutput *ValuesOutput) {
+	if valuesInput.Fluentd.Logs == nil ||
+		valuesInput.Fluentd.Logs.Autoscaling == nil ||
+		valuesInput.Fluentd.Logs.Autoscaling.Enabled == nil ||
+		!*valuesInput.Fluentd.Logs.Autoscaling.Enabled {
+		return
+	}
+
+	if valuesOutput.Metadata == nil {
+		valuesOutput.Metadata = &Metadata{}
+	}
+
+	if valuesOutput.Metadata.Logs == nil {
+		valuesOutput.Metadata.Logs = &MetadataLogs{}
+	}
+
+	if valuesOutput.Metadata.Logs.Autoscaling == nil {
+		valuesOutput.Metadata.Logs.Autoscaling = &Autoscaling{}
+	}
+
+	if valuesOutput.Metadata.Logs.Autoscaling.Enabled == nil {
+		valuesOutput.Metadata.Logs.Autoscaling.Enabled = new(bool)
+		*valuesOutput.Metadata.Logs.Autoscaling.Enabled = true
+	}
+}

--- a/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/migrate_test.go
+++ b/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/migrate_test.go
@@ -1,0 +1,160 @@
+package fluentdautoscaling
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type TestCase struct {
+	inputYaml   string
+	outputYaml  string
+	err         error
+	description string
+}
+
+func runYamlTest(t *testing.T, testCase TestCase) {
+	actualOutput, err := Migrate(testCase.inputYaml)
+	if testCase.err == nil {
+		require.NoError(t, err, testCase.description)
+	} else {
+		require.Equal(t, err, testCase.err, testCase.description)
+	}
+	require.Equal(t, strings.Trim(testCase.outputYaml, "\n "), strings.Trim(actualOutput, "\n "), testCase.description)
+}
+
+func Test_EventsEnabledProvider(t *testing.T) {
+	testCases := []TestCase{
+		{
+			inputYaml:   `{}`,
+			outputYaml:  `{}`,
+			description: "No config, no change",
+		},
+		{
+			inputYaml: `
+fluentd:
+  key: value
+`,
+			outputYaml: `
+fluentd:
+  key: value
+`,
+			description: "No config, no change",
+		},
+		{
+			inputYaml: `
+fluentd:
+  logs:
+    key: value
+  metrics:
+    key: value
+`,
+			outputYaml: `
+fluentd:
+  logs:
+    key: value
+  metrics:
+    key: value
+`,
+			description: "No config, no change",
+		},
+		{
+			inputYaml: `
+fluentd:
+  logs:
+    autoscaling:
+      minReplicas: 5
+  metrics:
+    autoscaling:
+      minReplicas: 5
+`,
+			outputYaml: `
+fluentd:
+  logs:
+    autoscaling:
+      minReplicas: 5
+  metrics:
+    autoscaling:
+      minReplicas: 5
+`,
+			description: "No config, no change",
+		},
+		{
+			inputYaml: `
+fluentd:
+  logs:
+    autoscaling:
+      enabled: true
+      minReplicas: 5
+  metrics:
+    autoscaling:
+      enabled: true
+      minReplicas: 5
+`,
+			outputYaml: `
+metadata:
+  logs:
+    autoscaling:
+      enabled: true
+  metrics:
+    autoscaling:
+      enabled: true
+fluentd:
+  logs:
+    autoscaling:
+      enabled: true
+      minReplicas: 5
+  metrics:
+    autoscaling:
+      enabled: true
+      minReplicas: 5
+`,
+			description: "Enabled, everything else unchanged",
+		},
+		{
+			inputYaml: `
+metadata:
+  logs:
+    autoscaling:
+      enabled: false
+  metrics:
+    autoscaling:
+      enabled: false
+fluentd:
+  logs:
+    autoscaling:
+      enabled: true
+      minReplicas: 5
+  metrics:
+    autoscaling:
+      enabled: true
+      minReplicas: 5
+`,
+			outputYaml: `
+metadata:
+  logs:
+    autoscaling:
+      enabled: false
+  metrics:
+    autoscaling:
+      enabled: false
+fluentd:
+  logs:
+    autoscaling:
+      enabled: true
+      minReplicas: 5
+  metrics:
+    autoscaling:
+      enabled: true
+      minReplicas: 5
+`,
+			description: "Do nothing if metadata autoscaling already disabled",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			runYamlTest(t, testCase)
+		})
+	}
+}

--- a/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/values_input.go
+++ b/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/values_input.go
@@ -1,0 +1,7 @@
+package fluentdautoscaling
+
+type ValuesInput struct {
+	Metadata *Metadata              `yaml:"metadata,omitempty"`
+	Fluentd  *Fluentd               `yaml:"fluentd,omitempty"`
+	Rest     map[string]interface{} `yaml:",inline"`
+}

--- a/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/values_output.go
+++ b/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/values_output.go
@@ -1,0 +1,7 @@
+package fluentdautoscaling
+
+type ValuesOutput struct {
+	Metadata *Metadata              `yaml:"metadata,omitempty"`
+	Fluentd  *Fluentd               `yaml:"fluentd,omitempty"`
+	Rest     map[string]interface{} `yaml:",inline"`
+}

--- a/src/go/cmd/update-collection-v3/migrations/fluentd-logs-configs/fluentd.go
+++ b/src/go/cmd/update-collection-v3/migrations/fluentd-logs-configs/fluentd.go
@@ -17,6 +17,11 @@ func createSumologic(valuesInput *ValuesInput) *SumologicOutput {
 	if valuesInput.Sumologic != nil {
 		sumoLogicOutput.Rest = valuesInput.Sumologic.Rest
 	}
+
+	if sumoLogicOutput.Logs == nil && len(sumoLogicOutput.Rest) == 0 {
+		sumoLogicOutput = nil
+	}
+
 	return sumoLogicOutput
 }
 
@@ -39,6 +44,11 @@ func createSumologicLogs(fluentdLogsInput *FluentdLogs, sumologicLogsInput *Sumo
 	if sumologicLogsInput != nil {
 		sumologicLogsOutput.Rest = sumologicLogsInput.Rest
 	}
+
+	if sumologicLogsOutput.empty() {
+		sumologicLogsOutput = nil
+	}
+
 	return sumologicLogsOutput
 }
 
@@ -184,4 +194,15 @@ func createFluentdLogs(valuesInput *ValuesInput) *Fluentd {
 			Rest:       valuesInput.Fluentd.Logs.Rest,
 		},
 	}
+}
+
+func (sumologicLogsOutput *SumologicLogsOutput) empty() bool {
+	if sumologicLogsOutput.Container == nil &&
+		sumologicLogsOutput.Systemd == nil &&
+		sumologicLogsOutput.Kubelet == nil &&
+		sumologicLogsOutput.Default == nil &&
+		len(sumologicLogsOutput.Rest) == 0 {
+		return true
+	}
+	return false
 }

--- a/src/go/cmd/update-collection-v3/migrations/fluentd-logs-configs/testdata/fluent-and-sumologic-without-logs.input.yaml
+++ b/src/go/cmd/update-collection-v3/migrations/fluentd-logs-configs/testdata/fluent-and-sumologic-without-logs.input.yaml
@@ -1,0 +1,7 @@
+fluentd:
+  logs:
+    autoscaling:
+      enabled: true
+      maxReplicas: 10
+      minReplicas: 3
+      targetCPUUtilizationPercentage: 50

--- a/src/go/cmd/update-collection-v3/migrations/fluentd-logs-configs/testdata/fluent-and-sumologic-without-logs.output.yaml
+++ b/src/go/cmd/update-collection-v3/migrations/fluentd-logs-configs/testdata/fluent-and-sumologic-without-logs.output.yaml
@@ -1,0 +1,7 @@
+fluentd:
+  logs:
+    autoscaling:
+      enabled: true
+      maxReplicas: 10
+      minReplicas: 3
+      targetCPUUtilizationPercentage: 50

--- a/src/go/cmd/update-collection-v3/testdata/simple.input.yaml
+++ b/src/go/cmd/update-collection-v3/testdata/simple.input.yaml
@@ -1,6 +1,12 @@
 fluentd:
   events:
     enabled: false
+  logs:
+    autoscaling:
+      enabled: true
+  metrics:
+    autoscaling:
+      enabled: true
 kube-prometheus-stack:
   prometheus:
     prometheusSpec:

--- a/src/go/cmd/update-collection-v3/testdata/simple.output.yaml
+++ b/src/go/cmd/update-collection-v3/testdata/simple.output.yaml
@@ -1,9 +1,20 @@
+fluentd:
+  logs:
+    autoscaling:
+      enabled: true
+  metrics:
+    autoscaling:
+      enabled: true
 metadata:
   logs:
+    autoscaling:
+      enabled: true
     config:
       merge:
         keylogs: valuelogs
   metrics:
+    autoscaling:
+      enabled: true
     config:
       merge:
         keymetrics: valuemetrics


### PR DESCRIPTION
This is a quality of life migration. If the user enabled autoscaling for FluentD, they presumably want it as well for otel. Otherwise we'd instead need to have users take manual steps to enable this, which is less convenient and makes the migration document longer and more complex.

I also fixed a small issue around handling empty structs in a different migration.