### PR TITLE
chore(receiver-mock): bump base64 to 0.21.0

### DIFF
--- a/src/rust/receiver-mock/Cargo.lock
+++ b/src/rust/receiver-mock/Cargo.lock
@@ -351,9 +351,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bit-set"
@@ -1489,7 +1489,7 @@ dependencies = [
  "actix-service 1.0.6",
  "actix-web",
  "anyhow",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bytes",
  "chrono",
  "clap",

--- a/src/rust/receiver-mock/Cargo.toml
+++ b/src/rust/receiver-mock/Cargo.toml
@@ -13,7 +13,7 @@ actix-service = "1"
 actix-rt = "2"
 anyhow = "1.0.68"
 bytes = "1"
-base64 = "0.20"
+base64 = "0.21"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 clap = "4.1.1"

--- a/src/rust/receiver-mock/src/router/api.rs
+++ b/src/rust/receiver-mock/src/router/api.rs
@@ -1,6 +1,6 @@
 pub mod v1 {
     use actix_web::{HttpRequest, HttpResponse, Responder};
-    use base64;
+    use base64::{engine::general_purpose as b64, Engine as _};
     use serde::{Deserialize, Serialize};
 
     #[derive(Deserialize, Serialize)]
@@ -28,7 +28,7 @@ pub mod v1 {
         };
 
         // For now the token is only checked if it can be decoded successfully.
-        let _decoded = match base64::decode(val) {
+        let _decoded = match b64::STANDARD.decode(val) {
             Ok(v) => v,
             Err(_) => {
                 return HttpResponse::Unauthorized().finish();


### PR DESCRIPTION
Made the necessary changes for #414 to succeed.