### PR TITLE
chore: change k8s.gcr.io registry to registry.k8s.io

### DIFF
--- a/src/go/cmd/update-collection-v3/migrations/kube-prometheus-stack-repository/testdata/all_values.input.yaml
+++ b/src/go/cmd/update-collection-v3/migrations/kube-prometheus-stack-repository/testdata/all_values.input.yaml
@@ -6,7 +6,7 @@ prometheusOperator:
   admissionWebhooks:
     patch:
       image:
-        repository: k8s.gcr.io/ingress-nginx/kube-webhook-certgen
+        repository: registry.k8s.io/ingress-nginx/kube-webhook-certgen
   image:
     repository: quay.io/prometheus-operator/prometheus-operator
   prometheusConfigReloader:

--- a/src/go/cmd/update-collection-v3/migrations/kube-prometheus-stack-repository/testdata/all_values.output.yaml
+++ b/src/go/cmd/update-collection-v3/migrations/kube-prometheus-stack-repository/testdata/all_values.output.yaml
@@ -10,7 +10,7 @@ prometheusOperator:
   admissionWebhooks:
     patch:
       image:
-        repository: k8s.gcr.io/ingress-nginx/kube-webhook-certgen
+        repository: registry.k8s.io/ingress-nginx/kube-webhook-certgen
   image:
     repository: quay.io/prometheus-operator/prometheus-operator
   prometheusConfigReloader:


### PR DESCRIPTION
https://kubernetes.io/blog/2023/03/10/image-registry-redirect/