### PR TITLE
Fix deprecations in github actions

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -19,7 +19,7 @@ jobs:
         id: extract_tag
         run: |
           tag=$(git describe --tags)
-          echo "::set-output name=tag::$(echo ${tag#v})"
+          echo "tag=$(echo ${tag#v})" >> $GITHUB_OUTPUT
       - name: Print tag
         run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
   build-and-push-image:

--- a/.github/workflows/pre_release_builds.yml
+++ b/.github/workflows/pre_release_builds.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
       - name: Print tag
         run: echo "Running pre release build for ${{ steps.extract_tag.outputs.tag }}"
   build-and-push-image:

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
       - name: Print tag
         run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
   build-and-push-image:


### PR DESCRIPTION
remove _set-output_ based on https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/