### PR TITLE
feat(update-collection-v3): check for conflicts between input and output yamls in migrations

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.18'
+          go-version: '1.21'
       - name: Build update-collection-v3
         run: make build-update-collection-v3
       - name: Test update-collection-v3

--- a/src/go/cmd/update-collection-v3/helpers/helpers.go
+++ b/src/go/cmd/update-collection-v3/helpers/helpers.go
@@ -1,0 +1,103 @@
+package helpers
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// CheckForConflictsInRest checks if Rest property contains structure properties keys
+func CheckForConflictsInRest(obj interface{}) ([]string, error) {
+	return CheckForConflictsInRestRecursive(reflect.ValueOf(obj), obj, "")
+}
+
+// Runs CheckForConflictsInRestRecursive recursively checks is Rest field contains duplication of any property
+func CheckForConflictsInRestRecursive(v reflect.Value, obj interface{}, prefix string) ([]string, error) {
+	knownProperties := getKnownProperties(obj)
+	duplicated := []string{}
+	var e error = nil
+
+	// Handle pointers to structs
+	if v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Struct {
+		v = v.Elem()
+	}
+
+	// Skip if element is not a structure
+	if v.Kind() != reflect.Struct {
+		return duplicated, nil
+	}
+
+	t := v.Type()
+	// Take rest field
+	rest := v.FieldByName("Rest")
+	if rest.IsValid() {
+		for _, key := range rest.MapKeys() {
+			keyStr := key.String()
+			if contains(knownProperties, keyStr) {
+				duplicated = append(duplicated, fmt.Sprintf("%s%s", prefix, keyStr))
+			}
+		}
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		fieldValue := v.Field(i)
+		structField := t.Field(i)
+
+		if !fieldValue.CanInterface() {
+			continue
+		}
+
+		d, _ := CheckForConflictsInRestRecursive(fieldValue, fieldValue.Interface(), fmt.Sprintf("%v%v.", prefix, getTagName(structField)))
+		duplicated = append(duplicated, d...)
+	}
+
+	if len(duplicated) > 0 {
+		e = fmt.Errorf("conflict between input and output values for the following keys: %s", strings.Join(duplicated, ", "))
+	}
+	return duplicated, e
+}
+
+func contains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper function to get the known property names from the struct's field tags
+func getKnownProperties(s interface{}) []string {
+	var knownProperties []string
+	v := reflect.ValueOf(s)
+
+	// Handle pointers to structs
+	if v.Kind() == reflect.Ptr && v.Elem().Kind() == reflect.Struct {
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		return []string{}
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tag := getTagName(field)
+
+		if tag == "" {
+			continue
+		}
+		knownProperties = append(knownProperties, tag)
+	}
+	return knownProperties
+}
+
+func getTagName(field reflect.StructField) string {
+	tag := field.Tag.Get("yaml")
+	parts := strings.Split(tag, ",")
+	if len(parts) != 2 || parts[0] == "" || parts[0] == "-" {
+		return ""
+	}
+
+	return parts[0]
+}

--- a/src/go/cmd/update-collection-v3/helpers/helpers.go
+++ b/src/go/cmd/update-collection-v3/helpers/helpers.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 )
 
@@ -33,7 +34,7 @@ func CheckForConflictsInRestRecursive(v reflect.Value, obj interface{}, prefix s
 	if rest.IsValid() {
 		for _, key := range rest.MapKeys() {
 			keyStr := key.String()
-			if contains(knownProperties, keyStr) {
+			if slices.Contains(knownProperties, keyStr) {
 				duplicated = append(duplicated, fmt.Sprintf("%s%s", prefix, keyStr))
 			}
 		}
@@ -55,15 +56,6 @@ func CheckForConflictsInRestRecursive(v reflect.Value, obj interface{}, prefix s
 		e = fmt.Errorf("conflict between input and output values for the following keys: %s", strings.Join(duplicated, ", "))
 	}
 	return duplicated, e
-}
-
-func contains(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
 }
 
 // Helper function to get the known property names from the struct's field tags

--- a/src/go/cmd/update-collection-v3/helpers/helpers_test.go
+++ b/src/go/cmd/update-collection-v3/helpers/helpers_test.go
@@ -1,0 +1,49 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForDuplicatedValue(t *testing.T) {
+	type nest struct {
+		str  string                 `yaml:"str,omitempty"`
+		Rest map[string]interface{} `yaml:",inline"`
+	}
+
+	type noRest struct {
+		str string `yaml:"str,omitempty"`
+	}
+
+	type main struct {
+		Str    string                 `yaml:"str,omitempty"`
+		i      int                    `yaml:"int,omitempty"`
+		Nest   nest                   `yaml:"nest,omitempty"`
+		Ptr    *nest                  `yaml:"ptr,omitempty"`
+		Rest   map[string]interface{} `yaml:",inline"`
+		NoRest noRest                 `yaml:"noRest,omitempty"`
+	}
+
+	a := &main{
+		Rest: map[string]interface{}{
+			"str": "",
+		},
+		Nest: nest{
+			str: "test",
+			Rest: map[string]interface{}{
+				"str": "test",
+			},
+		},
+		Ptr: &nest{
+			Rest: map[string]interface{}{
+				"str": "test",
+			},
+		},
+		i: 3,
+	}
+
+	ret, err := CheckForConflictsInRest(a)
+	assert.EqualError(t, err, "conflict between input and output values for the following keys: str, nest.str, ptr.str")
+	assert.Equal(t, []string{"str", "nest.str", "ptr.str"}, ret)
+}

--- a/src/go/cmd/update-collection-v3/migrations/disable-thanos/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/disable-thanos/migrate.go
@@ -3,6 +3,7 @@ package disablethanos
 import (
 	"bytes"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -13,6 +14,10 @@ func Migrate(inputYaml string) (string, error) {
 		return "", err
 	}
 	outputValues, err := migrate(&inputValues)
+	if err != nil {
+		return "", err
+	}
+	_, err = helpers.CheckForConflictsInRest(outputValues)
 	if err != nil {
 		return "", err
 	}

--- a/src/go/cmd/update-collection-v3/migrations/events-config-merge/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/events-config-merge/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -41,6 +42,10 @@ func Migrate(inputYaml string) (outputYaml string, err error) {
 	outputValues, err := migrate(&inputValues)
 	if err != nil {
 		return "", fmt.Errorf("error migrating: %v", err)
+	}
+	_, err = helpers.CheckForConflictsInRest(outputValues)
+	if err != nil {
+		return "", err
 	}
 
 	buffer := bytes.Buffer{}

--- a/src/go/cmd/update-collection-v3/migrations/events/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/events/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,6 +17,10 @@ func Migrate(yamlV2 string) (yamlV3 string, err error) {
 	valuesV3, err := migrate(&valuesV2)
 	if err != nil {
 		return "", fmt.Errorf("error migrating: %v", err)
+	}
+	_, err = helpers.CheckForConflictsInRest(valuesV3)
+	if err != nil {
+		return "", err
 	}
 
 	buffer := bytes.Buffer{}

--- a/src/go/cmd/update-collection-v3/migrations/falco-upgrade/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/falco-upgrade/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -66,6 +67,10 @@ Please confirm that migrated configuration is correct according to Falco helm ch
 				values.Falco.Ebpf.Enabled = nil
 			}
 		}
+	}
+	_, err = helpers.CheckForConflictsInRest(values)
+	if err != nil {
+		return "", err
 	}
 
 	buffer := bytes.Buffer{}

--- a/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/fluentd-autoscaling/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -14,6 +15,10 @@ func Migrate(input string) (string, error) {
 	}
 
 	valuesOutput := migrate(&valuesInput)
+	_, err = helpers.CheckForConflictsInRest(valuesOutput)
+	if err != nil {
+		return "", err
+	}
 
 	buffer := bytes.Buffer{}
 	encoder := yaml.NewEncoder(&buffer)

--- a/src/go/cmd/update-collection-v3/migrations/fluentd-logs-configs/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/fluentd-logs-configs/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -19,6 +20,10 @@ func Migrate(input string) (string, error) {
 	}
 
 	valuesOutput := migrate(&valuesInput)
+	_, err = helpers.CheckForConflictsInRest(valuesOutput)
+	if err != nil {
+		return "", err
+	}
 
 	buffer := bytes.Buffer{}
 	encoder := yaml.NewEncoder(&buffer)

--- a/src/go/cmd/update-collection-v3/migrations/kube-prometheus-stack-repository/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/kube-prometheus-stack-repository/migrate.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -69,6 +70,10 @@ func Migrate(inputYaml string) (outputYaml string, err error) {
 	values = migrate(&values)
 	if err != nil {
 		return "", fmt.Errorf("error migrating: %v", err)
+	}
+	_, err = helpers.CheckForConflictsInRest(values)
+	if err != nil {
+		return "", err
 	}
 
 	buffer := bytes.Buffer{}

--- a/src/go/cmd/update-collection-v3/migrations/kube-state-metrics-collectors/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/kube-state-metrics-collectors/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,6 +17,10 @@ func Migrate(yamlV2 string) (yamlV3 string, err error) {
 	valuesV3, err := migrate(&valuesV2)
 	if err != nil {
 		return "", fmt.Errorf("error migrating: %v", err)
+	}
+	_, err = helpers.CheckForConflictsInRest(valuesV3)
+	if err != nil {
+		return "", err
 	}
 
 	buffer := bytes.Buffer{}

--- a/src/go/cmd/update-collection-v3/migrations/logformat/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/logformat/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,6 +17,10 @@ func Migrate(inputYaml string) (outputYaml string, err error) {
 	outputValues := migrate(&inputValues)
 	if err != nil {
 		return "", fmt.Errorf("error migrating: %v", err)
+	}
+	_, err = helpers.CheckForConflictsInRest(outputValues)
+	if err != nil {
+		return "", err
 	}
 
 	buffer := bytes.Buffer{}

--- a/src/go/cmd/update-collection-v3/migrations/logs-metadata-config/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/logs-metadata-config/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -45,6 +46,10 @@ func Migrate(inputYaml string) (outputYaml string, err error) {
 	outputValues, err := migrate(&inputValues)
 	if err != nil {
 		return "", fmt.Errorf("error migrating: %v", err)
+	}
+	_, err = helpers.CheckForConflictsInRest(outputValues)
+	if err != nil {
+		return "", err
 	}
 
 	buffer := bytes.Buffer{}

--- a/src/go/cmd/update-collection-v3/migrations/metrics-metadata-config/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/metrics-metadata-config/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -45,6 +46,10 @@ func Migrate(inputYaml string) (outputYaml string, err error) {
 	outputValues, err := migrate(&inputValues)
 	if err != nil {
 		return "", fmt.Errorf("error migrating: %v", err)
+	}
+	_, err = helpers.CheckForConflictsInRest(outputValues)
+	if err != nil {
+		return "", err
 	}
 
 	buffer := bytes.Buffer{}

--- a/src/go/cmd/update-collection-v3/migrations/otellogs-config-merge/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/otellogs-config-merge/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -41,6 +42,10 @@ func Migrate(inputYaml string) (outputYaml string, err error) {
 	outputValues, err := migrate(&inputValues)
 	if err != nil {
 		return "", fmt.Errorf("error migrating: %v", err)
+	}
+	_, err = helpers.CheckForConflictsInRest(outputValues)
+	if err != nil {
+		return "", err
 	}
 
 	buffer := bytes.Buffer{}

--- a/src/go/cmd/update-collection-v3/migrations/remove-load-config-file/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/remove-load-config-file/migrate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -29,6 +30,10 @@ func Migrate(inputYaml string) (outputYaml string, err error) {
 	outputValues, err := migrate(&values)
 	if err != nil {
 		return "", fmt.Errorf("error migrating: %v", err)
+	}
+	_, err = helpers.CheckForConflictsInRest(outputValues)
+	if err != nil {
+		return "", err
 	}
 
 	buffer := bytes.Buffer{}

--- a/src/go/cmd/update-collection-v3/migrations/tracing-config/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/tracing-config/migrate.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 )
 
 func Migrate(input string) (string, error) {
@@ -22,6 +24,10 @@ func Migrate(input string) (string, error) {
 		buffer := bytes.Buffer{}
 		encoder := yaml.NewEncoder(&buffer)
 		encoder.SetIndent(2)
+		_, err = helpers.CheckForConflictsInRest(outputValues)
+		if err != nil {
+			return "", err
+		}
 		err = encoder.Encode(outputValues)
 		fmt.Sprintln(buffer.String())
 		fmt.Println("WARNING! Tracing config migrated to v3, please check the output file. For more details see documentation: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/docs/v3-migration-doc.md#tracinginstrumentation-changes")

--- a/src/go/cmd/update-collection-v3/migrations/tracing-replaces/migrate.go
+++ b/src/go/cmd/update-collection-v3/migrations/tracing-replaces/migrate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/helpers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -63,6 +64,10 @@ func parseConfigToString(config Otelcol) (string, error) {
 func findUsedReplaces(config Otelcol, replaces []string) ([]string, error) {
 	if &config == nil {
 		return []string{}, nil
+	}
+	_, err := helpers.CheckForConflictsInRest(config)
+	if err != nil {
+		return []string{}, err
 	}
 
 	confStr, err := parseConfigToString(config)

--- a/src/go/go.mod
+++ b/src/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/SumoLogic/sumologic-kubernetes-collection/tools
 
-go 1.18
+go 1.21
 
 require (
 	github.com/goccy/go-yaml v1.11.0


### PR DESCRIPTION
This PR resolves the following case:

`inputStruct`
```
type in struct {
  Rest           map[string]interface{} `yaml:",inline,omitempty"`
}
```

`values.yaml`
```
out: test
```

`outputStruct`
```
type out struct {
  Out            string                 `yaml:"out,omitempty"`
  Rest           map[string]interface{} `yaml:",inline,omitempty"`
}
```

`out` is in both `Rest` and Out` properties of `out` structure which leads to panic:

e.g.

`input.yaml`
```
otelcolInstrumentation:
  enabled: false
```

`stdout`:
```
panic: cannot have key "otelcolInstrumentation" in inlined map: conflicts with struct field [recovered]
        panic: cannot have key "otelcolInstrumentation" in inlined map: conflicts with struct field

goroutine 1 [running]:
gopkg.in/yaml%2ev3.handleErr(0xc000133788)
        /home/drosiek/go/pkg/mod/gopkg.in/yaml.v3@v3.0.1/yaml.go:294 +0x6d
panic({0x55c340?, 0xc000031500?})
        /usr/lib/go/src/runtime/panic.go:914 +0x21f
gopkg.in/yaml%2ev3.(*encoder).structv.func1()
        /home/drosiek/go/pkg/mod/gopkg.in/yaml.v3@v3.0.1/encode.go:245 +0x479
gopkg.in/yaml%2ev3.(*encoder).mappingv(0xc000163800, {0x0?, 0x0}, 0xc000133528)
        /home/drosiek/go/pkg/mod/gopkg.in/yaml.v3@v3.0.1/encode.go:265 +0x14a
gopkg.in/yaml%2ev3.(*encoder).structv(0xc000163800, {0x0, 0x0}, {0x57d4c0?, 0xc00016d360?, 0x0?})
        /home/drosiek/go/pkg/mod/gopkg.in/yaml.v3@v3.0.1/encode.go:219 +0xe5
gopkg.in/yaml%2ev3.(*encoder).marshal(0xc000163800, {0x0, 0x0}, {0x57d4c0?, 0xc00016d360?, 0x5c6568?})
        /home/drosiek/go/pkg/mod/gopkg.in/yaml.v3@v3.0.1/encode.go:168 +0x8a8
gopkg.in/yaml%2ev3.(*encoder).marshalDoc(0xc000163800, {0x0, 0x0}, {0x57d4c0?, 0xc00016d360?, 0xc00016d360?})
        /home/drosiek/go/pkg/mod/gopkg.in/yaml.v3@v3.0.1/encode.go:105 +0x12e
gopkg.in/yaml%2ev3.(*Encoder).Encode(0x57d4c0?, {0x57d4c0?, 0xc00016d360?})
        /home/drosiek/go/pkg/mod/gopkg.in/yaml.v3@v3.0.1/yaml.go:251 +0xbe
github.com/SumoLogic/sumologic-kubernetes-collection/tools/cmd/update-collection-v3/migrations/tracing-config.Migrate({0xc00001c9c0?, 0x33?})
        /home/drosiek/projects/sumologic-kubernetes-tools/src/go/cmd/update-collection-v3/migrations/tracing-config/migrate.go:25 +0x4af
main.migrateYaml({0xc0000240f0, 0x2e})
        /home/drosiek/projects/sumologic-kubernetes-tools/src/go/cmd/update-collection-v3/main.go:156 +0x97
main.migrateYamlFile({0x7fff0c6abccd, 0xa}, {0x58fea0, 0xf})
        /home/drosiek/projects/sumologic-kubernetes-tools/src/go/cmd/update-collection-v3/main.go:63 +0x1aa
main.main()
        /home/drosiek/projects/sumologic-kubernetes-tools/src/go/cmd/update-collection-v3/main.go:45 +0x7c
```