### PR TITLE
fix(receiver-mock): restore --store-logs option

### DIFF
--- a/src/rust/receiver-mock/src/main.rs
+++ b/src/rust/receiver-mock/src/main.rs
@@ -74,7 +74,7 @@ struct Cli {
     print_headers: bool,
 
     #[arg(
-        long = "store-headers",
+        long = "store-logs",
         default_value_t = false,
         help = "Use to store log data which can then be queried via /logs/* endpoints"
     )]


### PR DESCRIPTION
#462 accidentally removed the `--store-logs` option for receiver-mock. This change brings it back.