### PR TITLE
deps(receiver-mock): drop dependency on http crate

### DIFF
--- a/src/rust/receiver-mock/Cargo.lock
+++ b/src/rust/receiver-mock/Cargo.lock
@@ -1363,7 +1363,6 @@ dependencies = [
  "clap",
  "fancy-regex",
  "hex",
- "http",
  "itertools 0.12.0",
  "json_str",
  "log",

--- a/src/rust/receiver-mock/Cargo.toml
+++ b/src/rust/receiver-mock/Cargo.toml
@@ -22,7 +22,6 @@ chrono = { version = "0.4", features = ["serde"] }
 json_str = "*"
 rand = "0.8"
 prometheus-parse = { git = "https://github.com/ccakes/prometheus-parse-rs", version = "0.2.4" }
-http = "0.2"
 opentelemetry-proto = { version = "0.3.0", features = ["gen-tonic", "logs", "metrics", "traces"] }
 prost = "0.11.0"
 itertools = "0.12.0"

--- a/src/rust/receiver-mock/src/router/mod.rs
+++ b/src/rust/receiver-mock/src/router/mod.rs
@@ -380,9 +380,9 @@ pub async fn handler_dump(body: web::Bytes) -> impl Responder {
 }
 
 pub fn print_request_headers(
-    method: &http::Method,
-    version: http::Version,
-    uri: &http::Uri,
+    method: &actix_http::Method,
+    version: actix_http::Version,
+    uri: &actix_http::Uri,
     headers: &actix_http::header::HeaderMap,
 ) {
     let method = method.as_str();


### PR DESCRIPTION
We only depend on this crate indirectly via actix_http. Dependabot wanted to update it independently, leading to build errors.

Supersedes #613 