### PR TITLE
chore: fix dockerhub secret names in builds

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -30,8 +30,8 @@ jobs:
       push_cache: true
       suffix: tools
     secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   build-and-push-image-kubectl:
@@ -41,8 +41,8 @@ jobs:
       build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
       suffix: kubectl
     secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN_KUBECTL }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD_KUBECTL }}
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_KUBECTL }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_KUBECTL }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_KUBECTL }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_KUBECTL }}
   build-and-push-image-sumologic-mock:
@@ -53,8 +53,8 @@ jobs:
       suffix: sumologic-mock
       push_cache: true
     secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN_SUMOLOGIC_MOCK }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD_SUMOLOGIC_MOCK }}
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_SUMOLOGIC_MOCK }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_SUMOLOGIC_MOCK }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_SUMOLOGIC_MOCK }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_SUMOLOGIC_MOCK }}
   build-binaries:

--- a/.github/workflows/pre_release_builds.yml
+++ b/.github/workflows/pre_release_builds.yml
@@ -26,8 +26,8 @@ jobs:
       build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
       suffix: tools
     secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   build-and-push-image-kubectl:
@@ -37,8 +37,8 @@ jobs:
       build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
       suffix: kubectl
     secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN_KUBECTL }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD_KUBECTL }}
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_KUBECTL }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_KUBECTL }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_KUBECTL }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_KUBECTL }}
   build-and-push-image-sumologic-mock:
@@ -48,7 +48,7 @@ jobs:
       build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
       suffix: sumologic-mock
     secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN_SUMOLOGIC_MOCK }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD_SUMOLOGIC_MOCK }}
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_SUMOLOGIC_MOCK }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_SUMOLOGIC_MOCK }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_SUMOLOGIC_MOCK }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_SUMOLOGIC_MOCK }}

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -25,8 +25,8 @@ jobs:
       tag_latest: true
       suffix: tools
     secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   build-and-push-image-kubectl:
@@ -37,8 +37,8 @@ jobs:
       tag_latest: true
       suffix: kubectl
     secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN_KUBECTL }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD_KUBECTL }}
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_KUBECTL }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_KUBECTL }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_KUBECTL }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_KUBECTL }}
   build-and-push-image-sumologic-mock:
@@ -49,8 +49,8 @@ jobs:
       tag_latest: true
       suffix: sumologic-mock
     secrets:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_LOGIN_SUMOLOGIC_MOCK }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD_SUMOLOGIC_MOCK }}
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_SUMOLOGIC_MOCK }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_SUMOLOGIC_MOCK }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_SUMOLOGIC_MOCK }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_SUMOLOGIC_MOCK }}
   build-binaries:


### PR DESCRIPTION
`DOCKER` -> `DOCKERHUB`