### PR TITLE
deps(sumologic-mock): bump opentelemetry-proto to 0.6.0

### DIFF
--- a/src/rust/sumologic-mock/Cargo.lock
+++ b/src/rust/sumologic-mock/Cargo.lock
@@ -621,21 +621,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,9 +1161,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1186,14 +1171,13 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "thiserror",
- "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1203,16 +1187,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
+ "lazy_static",
  "once_cell",
  "opentelemetry",
  "ordered-float",
@@ -1900,12 +1884,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/src/rust/sumologic-mock/Cargo.toml
+++ b/src/rust/sumologic-mock/Cargo.toml
@@ -22,7 +22,7 @@ chrono = { version = "0.4", features = ["serde"] }
 json_str = "*"
 rand = "0.8"
 prometheus-parse = { git = "https://github.com/ccakes/prometheus-parse-rs", version = "0.2.4" }
-opentelemetry-proto = { version = "0.5.0", features = ["gen-tonic", "logs", "metrics", "trace"] }
+opentelemetry-proto = { version = "0.6.0", features = ["gen-tonic", "logs", "metrics", "trace"] }
 prost = "0.12.4"
 itertools = "0.13.0"
 log = "0.4.21"

--- a/src/rust/sumologic-mock/src/router/otlp.rs
+++ b/src/rust/sumologic-mock/src/router/otlp.rs
@@ -443,6 +443,7 @@ mod sample {
                 description: String::new(),
                 unit: String::new(),
                 data: Some(data),
+                metadata: vec![],
             }
         }
 
@@ -786,6 +787,7 @@ mod test {
             description: "a test metric".to_string(),
             unit: "petaweber".to_string(),
             data: Some(metricsv1::metric::Data::Gauge(get_sample_gauge())),
+            metadata: vec![],
         }
     }
 


### PR DESCRIPTION
Supersedes #720, needed minor code changes.