### PR TITLE
feat: build kubectl UBI based image 

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "release-v[0-9]+.[0-9]+"
+      - "dev-build/*"
 
 jobs:
   extract-image-tag:

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - 'release-v[0-9]+.[0-9]+'
+      - "release-v[0-9]+.[0-9]+"
 
 jobs:
   extract-image-tag:
@@ -40,6 +40,17 @@ jobs:
     with:
       build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
       suffix: kubectl
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_KUBECTL }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_KUBECTL }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_KUBECTL }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_KUBECTL }}
+  build-and-push-image-kubectl-ubi:
+    uses: ./.github/workflows/build_and_push_image.yml
+    needs: extract-image-tag
+    with:
+      build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
+      suffix: kubectl-ubi
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_KUBECTL }}
       DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_KUBECTL }}

--- a/.github/workflows/pre_release_builds.yml
+++ b/.github/workflows/pre_release_builds.yml
@@ -41,6 +41,17 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_KUBECTL }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_KUBECTL }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_KUBECTL }}
+  build-and-push-image-kubectl-ubi:
+    uses: ./.github/workflows/build_and_push_image.yml
+    needs: extract-image-tag
+    with:
+      build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
+      suffix: kubectl-ubi
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_KUBECTL }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_KUBECTL }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_KUBECTL }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_KUBECTL }}
   build-and-push-image-sumologic-mock:
     uses: ./.github/workflows/build_and_push_image.yml
     needs: extract-image-tag

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -3,7 +3,7 @@ name: Release builds
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   extract-image-tag:
@@ -36,6 +36,18 @@ jobs:
       build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
       tag_latest: true
       suffix: kubectl
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_KUBECTL }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_KUBECTL }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_KUBECTL }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_KUBECTL }}
+  build-and-push-image-kubectl-ubi:
+    uses: ./.github/workflows/build_and_push_image.yml
+    needs: extract-image-tag
+    with:
+      build_tag: ${{ needs.extract-image-tag.outputs.build_tag }}
+      tag_latest: true
+      suffix: kubectl-ubi
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKERHUB_LOGIN_KUBECTL }}
       DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD_KUBECTL }}

--- a/Dockerfile.kubectl-ubi
+++ b/Dockerfile.kubectl-ubi
@@ -1,0 +1,25 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG BUILD_TAG
+
+ENV KUBECTL_VERSION="v1.26.4"
+ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /usr/bin/kubectl
+RUN chmod +x /usr/bin/kubectl
+
+ENV SUMMARY="UBI based Kubectl Sumo Logic Tools image" \
+    DESCRIPTION="Sumo Logic Tools image containing kubectl binary"
+
+LABEL name="Sumo Logic Kubernetes tools" \
+    vendor="Sumo Logic" \
+    version="${BUILD_TAG}" \
+    release="1" \
+    summary="$SUMMARY" \
+    description="$DESCRIPTION" \
+    maintainer="opensource-collection-team@sumologic.com"
+
+ADD LICENSE \
+    /licenses/LICENSE
+
+USER 65532:65532

--- a/Dockerfile.kubectl-ubi
+++ b/Dockerfile.kubectl-ubi
@@ -17,6 +17,7 @@ LABEL name="Sumo Logic Kubernetes tools" \
     release="1" \
     summary="$SUMMARY" \
     description="$DESCRIPTION" \
+    io.k8s.description="$DESCRIPTION" \
     maintainer="opensource-collection-team@sumologic.com"
 
 ADD LICENSE \

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ tag-release-image-with-latest-sumologic-mock:
 tag-release-image-with-latest-ecr-tools:
 	make tag-release-image-with-latest-tools REPO_URL=$(ECR_REPO_URL)
 
-tag-release-image-with-latest-ecr-kubectl-ubi:
-	make tag-release-image-with-latest-kubectl-ubi REPO_URL=$(ECR_REPO_URL)
+tag-release-image-with-latest-ecr-kubectl:
+	make tag-release-image-with-latest-kubectl REPO_URL=$(ECR_REPO_URL)
 
 tag-release-image-with-latest-ecr-kubectl-ubi:
 	make tag-release-image-with-latest-kubectl-ubi REPO_URL=$(ECR_REPO_URL)

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ delete-remote-tag:
 	@echo "Deleting remote tag ${TAG}"
 	@git push --delete origin ${TAG}
 
-build-image: build-image-tools build-image-kubectl build-image-sumologic-mock
+build-image: build-image-tools build-image-kubectl build-image-kubectl-ubi build-image-sumologic-mock
 
 build-image-tools:
 	TAG=$(BUILD_TAG) docker buildx bake
@@ -46,16 +46,22 @@ build-image-tools:
 build-image-kubectl:
 	TAG=$(BUILD_TAG) docker buildx bake kubectl
 
+build-image-kubectl-ubi:
+	TAG=$(BUILD_TAG) docker buildx bake kubectl-ubi
+
 build-image-sumologic-mock:
 	TAG=$(BUILD_TAG) docker buildx bake sumologic-mock
 
-build-image-multiplatform: build-image-multiplatform-tools build-image-multiplatform-kubectl
+build-image-multiplatform: build-image-multiplatform-tools build-image-multiplatform-kubectl build-image-multiplatform-kubectl-ubi
 
 build-image-multiplatform-tools:
 	TAG=$(BUILD_TAG) docker buildx bake tools-multiplatform
 
 build-image-multiplatform-kubectl:
 	TAG=$(BUILD_TAG) docker buildx bake kubectl-multiplatform
+
+build-image-multiplatform-kubectl-ubi:
+	TAG=$(BUILD_TAG) docker buildx bake kubectl-ubi-multiplatform
 
 build-image-multiplatform-sumologic-mock:
 	TAG=$(BUILD_TAG) docker buildx bake sumologic-mock-multiplatform
@@ -66,14 +72,20 @@ tag-release-image-with-latest-tools:
 tag-release-image-with-latest-kubectl:
 	make push-image-kubectl BUILD_TAG=latest
 
+tag-release-image-with-latest-kubectl-ubi:
+	make push-image-kubectl-ubi BUILD_TAG=latest
+
 tag-release-image-with-latest-sumologic-mock:
 	make push-image-sumologic-mock BUILD_TAG=latest
 
 tag-release-image-with-latest-ecr-tools:
 	make tag-release-image-with-latest-tools REPO_URL=$(ECR_REPO_URL)
 
-tag-release-image-with-latest-ecr-kubectl:
-	make tag-release-image-with-latest-kubectl REPO_URL=$(ECR_REPO_URL)
+tag-release-image-with-latest-ecr-kubectl-ubi:
+	make tag-release-image-with-latest-kubectl-ubi REPO_URL=$(ECR_REPO_URL)
+
+tag-release-image-with-latest-ecr-kubectl-ubi:
+	make tag-release-image-with-latest-kubectl-ubi REPO_URL=$(ECR_REPO_URL)
 
 tag-release-image-with-latest-ecr-sumologic-mock:
 	make tag-release-image-with-latest-sumologic-mock SUMOLOGIC_MOCK_REPO_URL=$(SUMOLOGIC_MOCK_ECR_REPO_URL)
@@ -97,6 +109,9 @@ push-image-tools:
 push-image-kubectl:
 	IMAGE=$(REPO_URL) TAG=$(BUILD_TAG) docker buildx bake kubectl-multiplatform --push
 
+push-image-kubectl-ubi:
+	IMAGE=$(REPO_URL) TAG=$(BUILD_TAG) docker buildx bake kubectl-ubi-multiplatform --push
+
 push-image-sumologic-mock:
 	SUMOLOGIC_MOCK_IMAGE=$(SUMOLOGIC_MOCK_REPO_URL) TAG=$(BUILD_TAG) docker buildx bake sumologic-mock-multiplatform --push
 
@@ -105,6 +120,9 @@ push-image-ecr-tools:
 
 push-image-ecr-kubectl:
 	make push-image-kubectl REPO_URL=$(ECR_REPO_URL)
+
+push-image-ecr-kubectl-ubi:
+	make push-image-kubectl-ubi REPO_URL=$(ECR_REPO_URL)
 
 push-image-ecr-sumologic-mock:
 	make push-image-sumologic-mock SUMOLOGIC_MOCK_REPO_URL=$(SUMOLOGIC_MOCK_ECR_REPO_URL)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -54,12 +54,26 @@ target "kubectl" {
     platforms = ["linux/amd64"]
 }
 
+target "kubectl-ubi" {
+    dockerfile = "Dockerfile.kubectl-ubi"
+    tags = ["${IMAGE}-kubectl:${TAG}-ubi"]
+    output = ["type=docker"]
+    platforms = ["linux/amd64"]
+    args = {
+        BUILD_TAG = "${TAG}"
+    }
+}
+
 target "tools-multiplatform" {
     inherits = ["default", "multiplatform"]
 }
 
 target "kubectl-multiplatform" {
     inherits = ["kubectl", "multiplatform"]
+}
+
+target "kubectl-ubi-multiplatform" {
+    inherits = ["kubectl-ubi", "multiplatform"]
 }
 
 target "sumologic-mock" {


### PR DESCRIPTION
```
preflight check container docker.io/sumologic/kubernetes-tools-kubectl:2.22.0-122-g169e321-ubi
time="2024-05-27T11:50:38+02:00" level=info msg="certification library version" version="0.0.0 <commit: 354d10d9af8b5a64c7c2230a6656186957c3ed9f>"
time="2024-05-27T11:50:40+02:00" level=info msg="running checks for docker.io/sumologic/kubernetes-tools-kubectl:2.22.0-122-g169e321-ubi for platform amd64"
time="2024-05-27T11:50:40+02:00" level=info msg="target image" image="docker.io/sumologic/kubernetes-tools-kubectl:2.22.0-122-g169e321-ubi"
time="2024-05-27T11:50:51+02:00" level=info msg="check completed" check=HasLicense result=PASSED
time="2024-05-27T11:50:51+02:00" level=info msg="check completed" check=HasUniqueTag result=PASSED
time="2024-05-27T11:50:51+02:00" level=info msg="check completed" check=LayerCountAcceptable result=PASSED
time="2024-05-27T11:50:51+02:00" level=info msg="check completed" check=HasNoProhibitedPackages result=PASSED
time="2024-05-27T11:50:51+02:00" level=info msg="check completed" check=HasRequiredLabel result=PASSED
time="2024-05-27T11:50:51+02:00" level=info msg="USER 65532:65532 specified that is non-root"
time="2024-05-27T11:50:51+02:00" level=info msg="check completed" check=RunAsNonRoot result=PASSED
time="2024-05-27T11:50:56+02:00" level=info msg="check completed" check=HasModifiedFiles result=PASSED
time="2024-05-27T11:50:58+02:00" level=info msg="check completed" check=BasedOnUbi result=PASSED
time="2024-05-27T11:50:58+02:00" level=info msg="This image's tag 2.22.0-122-g169e321-ubi will be paired with digest sha256:d8edac18b3aa36c3546a9835edff0a4df5dd3fabc9f411156c0008cc8726de5a once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
{
    "image": "docker.io/sumologic/kubernetes-tools-kubectl:2.22.0-122-g169e321-ubi",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "0.0.0",
        "commit": "354d10d9af8b5a64c7c2230a6656186957c3ed9f"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 0,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 21,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata."
            },
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication"
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 4726,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 1815,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            }
        ],
        "failed": [],
        "errors": []
    }
}
time="2024-05-27T11:50:58+02:00" level=info msg="Preflight result: PASSED"
time="2024-05-27T11:50:58+02:00" level=info msg="running checks for docker.io/sumologic/kubernetes-tools-kubectl:2.22.0-122-g169e321-ubi for platform arm64"
time="2024-05-27T11:50:58+02:00" level=info msg="target image" image="docker.io/sumologic/kubernetes-tools-kubectl:2.22.0-122-g169e321-ubi"
time="2024-05-27T11:51:09+02:00" level=info msg="check completed" check=HasLicense result=PASSED
time="2024-05-27T11:51:09+02:00" level=info msg="check completed" check=HasUniqueTag result=PASSED
time="2024-05-27T11:51:09+02:00" level=info msg="check completed" check=LayerCountAcceptable result=PASSED
time="2024-05-27T11:51:09+02:00" level=info msg="check completed" check=HasNoProhibitedPackages result=PASSED
time="2024-05-27T11:51:09+02:00" level=info msg="check completed" check=HasRequiredLabel result=PASSED
time="2024-05-27T11:51:09+02:00" level=info msg="USER 65532:65532 specified that is non-root"
time="2024-05-27T11:51:09+02:00" level=info msg="check completed" check=RunAsNonRoot result=PASSED
time="2024-05-27T11:51:13+02:00" level=info msg="check completed" check=HasModifiedFiles result=PASSED
time="2024-05-27T11:51:15+02:00" level=info msg="check completed" check=BasedOnUbi result=PASSED
time="2024-05-27T11:51:15+02:00" level=info msg="This image's tag 2.22.0-122-g169e321-ubi will be paired with digest sha256:1ff295982d712efa7b69e8685ebd4b53cc7d665beaff3ef57cdf8119d8a4758a once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
{
    "image": "docker.io/sumologic/kubernetes-tools-kubectl:2.22.0-122-g169e321-ubi",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "0.0.0",
        "commit": "354d10d9af8b5a64c7c2230a6656186957c3ed9f"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 0,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 21,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata."
            },
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication"
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 4462,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 1421,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            }
        ],
        "failed": [],
        "errors": []
    }
}
time="2024-05-27T11:51:15+02:00" level=info msg="Preflight result: PASSED"
```