### PR TITLE
deps(kubectl): update dependencies

### DIFF
--- a/Dockerfile.kubectl
+++ b/Dockerfile.kubectl
@@ -1,4 +1,4 @@
-FROM bash:5.2.15-alpine3.17
+FROM bash:5.2.26-alpine3.20
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/Dockerfile.kubectl
+++ b/Dockerfile.kubectl
@@ -3,6 +3,6 @@ FROM bash:5.2.26-alpine3.20
 ARG TARGETARCH
 ARG TARGETOS
 
-ENV KUBECTL_VERSION="v1.26.4"
+ENV KUBECTL_VERSION="v1.27.15"
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /usr/bin/kubectl
 RUN chmod +x /usr/bin/kubectl


### PR DESCRIPTION
Update the base image to `5.2.26-alpine3.20`. Not sure why dependabot doesn't do this, maybe the version has the wrong format?

Also update kubectl to the latest patch version in the 1.27 line.

This addresses the following CVEs:
 - https://www.cve.org/CVERecord?id=CVE-2023-5363
 - https://www.cve.org/CVERecord?id=CVE-2023-44487
 - https://www.cve.org/CVERecord?id=CVE-2023-45288