### PR TITLE
feat(sumologic-mock): Add support for ipv6 cluster

### DIFF
--- a/src/rust/sumologic-mock/src/main.rs
+++ b/src/rust/sumologic-mock/src/main.rs
@@ -150,7 +150,7 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
         fields: Mutex::new(HashMap::new()),
     });
 
-    info!("Sumo Logic Mock is listening on 0.0.0.0:{}!", port);
+    info!("Sumo Logic Mock is listening on [::]:{}!", port);
     let result = actix_web::HttpServer::new(move || {
         actix_web::App::new()
             // Middleware printing headers for all handlers.
@@ -266,7 +266,7 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
             // Set metrics payload limit to 100MB
             .app_data(web::PayloadConfig::default().limit(100 * 2 << 20))
     })
-    .bind(format!("0.0.0.0:{}", port))?
+    .bind(format!("[::]:{}", port))?
     .run()
     .await;
 

--- a/src/rust/sumologic-mock/src/main.rs
+++ b/src/rust/sumologic-mock/src/main.rs
@@ -150,8 +150,7 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
         fields: Mutex::new(HashMap::new()),
     });
 
-    info!("Sumo Logic Mock is listening on [::]:{}!", port);
-    let result = actix_web::HttpServer::new(move || {
+    let server = actix_web::HttpServer::new(move || {
         actix_web::App::new()
             // Middleware printing headers for all handlers.
             // For a more robust middleware implementation (in its own type)
@@ -265,10 +264,28 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
             .default_service(web::get().to(router::handler_receiver))
             // Set metrics payload limit to 100MB
             .app_data(web::PayloadConfig::default().limit(100 * 2 << 20))
-    })
-    .bind(format!("[::]:{}", port))?
-    .run()
-    .await;
+    });
+
+    // Try to bind to [::] --loopback to both ipv6 and ipv4 first, fallback to IPv4 only if it fails
+    let result = match server.bind(format!("[::]:{}", port)) {
+        Ok(server) => {
+            info!("Sumo Logic Mock is listening on [::]:{}!", port);
+            server.run().await
+        }
+        Err(_) => {
+            info!("Failed to bind to [::], falling back to 0.0.0.0:{}", port);
+            match server.bind(format!("0.0.0.0:{}", port)) {
+                Ok(server) => {
+                    info!("Sumo Logic Mock is listening on 0.0.0.0:{}!", port);
+                    server.run().await
+                }
+                Err(e) => {
+                    error!("Failed to bind to both [::] and 0.0.0.0: {}", e);
+                    return Err(e);
+                }
+            }
+        }
+    };
 
     match result {
         Ok(result) => Ok(result),

--- a/src/rust/sumologic-mock/src/main.rs
+++ b/src/rust/sumologic-mock/src/main.rs
@@ -155,7 +155,7 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
         let app_metadata = app_metadata.clone();
         let terraform_state = terraform_state.clone();
         let opts = opts.clone();
-        
+
         move || {
             actix_web::App::new()
                 // Middleware printing headers for all handlers.

--- a/src/rust/sumologic-mock/src/main.rs
+++ b/src/rust/sumologic-mock/src/main.rs
@@ -150,8 +150,13 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
         fields: Mutex::new(HashMap::new()),
     });
 
-    let create_server = || {
-        actix_web::HttpServer::new(move || {
+    let create_app = {
+        let app_state = app_state.clone();
+        let app_metadata = app_metadata.clone();
+        let terraform_state = terraform_state.clone();
+        let opts = opts.clone();
+        
+        move || {
             actix_web::App::new()
                 // Middleware printing headers for all handlers.
                 // For a more robust middleware implementation (in its own type)
@@ -265,18 +270,18 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
                 .default_service(web::get().to(router::handler_receiver))
                 // Set metrics payload limit to 100MB
                 .app_data(web::PayloadConfig::default().limit(100 * 2 << 20))
-        })
+        }
     };
 
-    // Try to bind to [::] --loopback to both ipv6 and ipv4 first, fallback to IPv4 only if it fails
-    let result = match create_server().bind(format!("[::]:{}", port)) {
+    // Try to bind to [::] first, fallback to IPv4 if it fails
+    let result = match actix_web::HttpServer::new(create_app.clone()).bind(format!("[::]:{}", port)) {
         Ok(server) => {
             info!("Sumo Logic Mock is listening on [::]:{}!", port);
             server.run().await
         }
         Err(_) => {
             info!("Failed to bind to [::], falling back to 0.0.0.0:{}", port);
-            match create_server().bind(format!("0.0.0.0:{}", port)) {
+            match actix_web::HttpServer::new(create_app).bind(format!("0.0.0.0:{}", port)) {
                 Ok(server) => {
                     info!("Sumo Logic Mock is listening on 0.0.0.0:{}!", port);
                     server.run().await

--- a/src/rust/sumologic-mock/src/main.rs
+++ b/src/rust/sumologic-mock/src/main.rs
@@ -150,131 +150,133 @@ async fn run_app(hostname: String, port: u16, opts: Options) -> std::io::Result<
         fields: Mutex::new(HashMap::new()),
     });
 
-    let server = actix_web::HttpServer::new(move || {
-        actix_web::App::new()
-            // Middleware printing headers for all handlers.
-            // For a more robust middleware implementation (in its own type)
-            // one can take a look at https://actix.rs/docs/middleware/
-            .wrap_fn(move |req, srv| {
-                if opts.print.headers {
-                    let headers = req.headers();
+    let create_server = || {
+        actix_web::HttpServer::new(move || {
+            actix_web::App::new()
+                // Middleware printing headers for all handlers.
+                // For a more robust middleware implementation (in its own type)
+                // one can take a look at https://actix.rs/docs/middleware/
+                .wrap_fn(move |req, srv| {
+                    if opts.print.headers {
+                        let headers = req.headers();
 
-                    router::print_request_headers(req.method(), req.version(), req.uri(), headers);
-                }
+                        router::print_request_headers(req.method(), req.version(), req.uri(), headers);
+                    }
 
-                thread::sleep(opts.delay_time);
+                    thread::sleep(opts.delay_time);
 
-                actix_web::dev::Service::call(&srv, req)
-            })
-            .app_data(app_state.clone()) // Mutable shared state
-            .app_data(web::Data::new(opts.clone()))
-            .route(
-                "/spans-list",
-                web::get().to(router::traces_data::handler_get_spans),
-            )
-            .route(
-                "/traces-list",
-                web::get().to(router::traces_data::handler_get_traces),
-            )
-            .route(
-                "/metrics-reset",
-                web::post().to(router::metrics_data::handler_metrics_reset),
-            )
-            .route(
-                "/metrics-list",
-                web::get().to(router::metrics_data::handler_metrics_list),
-            )
-            .route(
-                "/metrics-ips",
-                web::get().to(router::metrics_data::handler_metrics_ips),
-            )
-            .route(
-                "/metrics-samples",
-                web::get().to(router::metrics_data::handler_metrics_samples),
-            )
-            .route("/metrics", web::get().to(router::handler_metrics))
-            .route("/logs/count", web::get().to(router::handler_logs_count))
-            .service(
-                web::scope("/api/v1")
-                    .route(
-                        "/collector/register",
-                        web::post().to(router::api::v1::handler_collector_register),
-                    )
-                    .route(
-                        "/collector/heartbeat",
-                        web::post().to(router::api::v1::handler_collector_heartbeat),
-                    )
-                    .route(
-                        "/otCollectors/metadata",
-                        web::post().to(router::api::v1::handler_collector_metadata),
-                    )
-                    .route(
-                        "/collector/logs",
-                        web::post().to(router::otlp::handler_receiver_otlp_logs),
-                    )
-                    .route(
-                        "/collector/metrics",
-                        web::post().to(router::otlp::handler_receiver_otlp_metrics),
-                    )
-                    .route(
-                        "/collector/traces",
-                        web::post().to(router::otlp::handler_receiver_otlp_traces),
-                    ),
-            )
-            .service(
-                web::scope("/terraform")
-                    .app_data(app_metadata.clone())
-                    .app_data(terraform_state.clone())
-                    .route(
-                        "/api/v1/fields/quota",
-                        web::get().to(router::terraform::handler_terraform_fields_quota),
-                    )
-                    .route(
-                        "/api/v1/fields/{field}",
-                        web::get().to(router::terraform::handler_terraform_field),
-                    )
-                    .route(
-                        "/api/v1/fields",
-                        web::get().to(router::terraform::handler_terraform_fields),
-                    )
-                    .route(
-                        "/api/v1/fields",
-                        web::post().to(router::terraform::handler_terraform_fields_create),
-                    )
-                    .default_service(web::get().to(router::terraform::handler_terraform)),
-            )
-            .route("/dump", web::post().to(router::handler_dump))
-            // OTLP
-            .service(
-                web::scope("/receiver/v1")
-                    .route(
-                        "/logs",
-                        web::post().to(router::otlp::handler_receiver_otlp_logs),
-                    )
-                    .route(
-                        "/metrics",
-                        web::post().to(router::otlp::handler_receiver_otlp_metrics),
-                    )
-                    .route(
-                        "/traces",
-                        web::post().to(router::otlp::handler_receiver_otlp_traces),
-                    ),
-            )
-            // Treat every other url as receiver endpoint
-            .default_service(web::get().to(router::handler_receiver))
-            // Set metrics payload limit to 100MB
-            .app_data(web::PayloadConfig::default().limit(100 * 2 << 20))
-    });
+                    actix_web::dev::Service::call(&srv, req)
+                })
+                .app_data(app_state.clone()) // Mutable shared state
+                .app_data(web::Data::new(opts.clone()))
+                .route(
+                    "/spans-list",
+                    web::get().to(router::traces_data::handler_get_spans),
+                )
+                .route(
+                    "/traces-list",
+                    web::get().to(router::traces_data::handler_get_traces),
+                )
+                .route(
+                    "/metrics-reset",
+                    web::post().to(router::metrics_data::handler_metrics_reset),
+                )
+                .route(
+                    "/metrics-list",
+                    web::get().to(router::metrics_data::handler_metrics_list),
+                )
+                .route(
+                    "/metrics-ips",
+                    web::get().to(router::metrics_data::handler_metrics_ips),
+                )
+                .route(
+                    "/metrics-samples",
+                    web::get().to(router::metrics_data::handler_metrics_samples),
+                )
+                .route("/metrics", web::get().to(router::handler_metrics))
+                .route("/logs/count", web::get().to(router::handler_logs_count))
+                .service(
+                    web::scope("/api/v1")
+                        .route(
+                            "/collector/register",
+                            web::post().to(router::api::v1::handler_collector_register),
+                        )
+                        .route(
+                            "/collector/heartbeat",
+                            web::post().to(router::api::v1::handler_collector_heartbeat),
+                        )
+                        .route(
+                            "/otCollectors/metadata",
+                            web::post().to(router::api::v1::handler_collector_metadata),
+                        )
+                        .route(
+                            "/collector/logs",
+                            web::post().to(router::otlp::handler_receiver_otlp_logs),
+                        )
+                        .route(
+                            "/collector/metrics",
+                            web::post().to(router::otlp::handler_receiver_otlp_metrics),
+                        )
+                        .route(
+                            "/collector/traces",
+                            web::post().to(router::otlp::handler_receiver_otlp_traces),
+                        ),
+                )
+                .service(
+                    web::scope("/terraform")
+                        .app_data(app_metadata.clone())
+                        .app_data(terraform_state.clone())
+                        .route(
+                            "/api/v1/fields/quota",
+                            web::get().to(router::terraform::handler_terraform_fields_quota),
+                        )
+                        .route(
+                            "/api/v1/fields/{field}",
+                            web::get().to(router::terraform::handler_terraform_field),
+                        )
+                        .route(
+                            "/api/v1/fields",
+                            web::get().to(router::terraform::handler_terraform_fields),
+                        )
+                        .route(
+                            "/api/v1/fields",
+                            web::post().to(router::terraform::handler_terraform_fields_create),
+                        )
+                        .default_service(web::get().to(router::terraform::handler_terraform)),
+                )
+                .route("/dump", web::post().to(router::handler_dump))
+                // OTLP
+                .service(
+                    web::scope("/receiver/v1")
+                        .route(
+                            "/logs",
+                            web::post().to(router::otlp::handler_receiver_otlp_logs),
+                        )
+                        .route(
+                            "/metrics",
+                            web::post().to(router::otlp::handler_receiver_otlp_metrics),
+                        )
+                        .route(
+                            "/traces",
+                            web::post().to(router::otlp::handler_receiver_otlp_traces),
+                        ),
+                )
+                // Treat every other url as receiver endpoint
+                .default_service(web::get().to(router::handler_receiver))
+                // Set metrics payload limit to 100MB
+                .app_data(web::PayloadConfig::default().limit(100 * 2 << 20))
+        })
+    };
 
     // Try to bind to [::] --loopback to both ipv6 and ipv4 first, fallback to IPv4 only if it fails
-    let result = match server.bind(format!("[::]:{}", port)) {
+    let result = match create_server().bind(format!("[::]:{}", port)) {
         Ok(server) => {
             info!("Sumo Logic Mock is listening on [::]:{}!", port);
             server.run().await
         }
         Err(_) => {
             info!("Failed to bind to [::], falling back to 0.0.0.0:{}", port);
-            match server.bind(format!("0.0.0.0:{}", port)) {
+            match create_server().bind(format!("0.0.0.0:{}", port)) {
                 Ok(server) => {
                     info!("Sumo Logic Mock is listening on 0.0.0.0:{}!", port);
                     server.run().await


### PR DESCRIPTION
Sumologic mock fails to run and stuck in crashloop state in ipv6 only clusters since it binds [to 0.0.0.0](https://github.com/SumoLogic/sumologic-kubernetes-tools/blob/main/src/rust/sumologic-mock/src/main.rs#L269) 

Changes made:
1. Bind to [::] - default loopback address for ipv6 and ipv4 (dual-stack clusters) 
2. If binding to [::] fails, probably it's ipv4 only cluster, fall back to using ipv4 loopback address 0.0.0.0

tests done:
1. Ran sumologic mock container in [::] dual stack loopback address and ensured that we can connect with ipv4 and ipv6 addresses.

Run sumologic-mock and logs..
.
.
<img width="1150" alt="Screenshot 2025-06-30 at 7 36 56 PM" src="https://github.com/user-attachments/assets/bea5e2c9-5a68-4e5e-8493-e86685e8af32" />
.
.
.
Connecting and accessing metrics via 3000 port with ipv4 and ipv6 addresses:

<img width="1106" alt="Screenshot 2025-06-30 at 7 36 41 PM" src="https://github.com/user-attachments/assets/aca1df7b-3e3d-495e-89fb-33b17172b153" />
 
.
.
.
Fallback when [::] fails

<img width="1033" alt="Screenshot 2025-06-30 at 7 56 33 PM" src="https://github.com/user-attachments/assets/76d569d5-431c-4a73-a9c7-078b40b9d6b4" />

 

