### PR TITLE
fix: add package upgrades and bump kubectl to v1.35.3 to resolve CVEs

### DIFF
--- a/Dockerfile.kubectl
+++ b/Dockerfile.kubectl
@@ -3,7 +3,7 @@ FROM bash:5.3.0-alpine3.22
 ARG TARGETARCH
 ARG TARGETOS
 
-RUN apk update && apk upgrade --no-cache
+RUN apk upgrade --no-cache
 
 ENV KUBECTL_VERSION="v1.35.3"
 ADD https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /usr/bin/kubectl

--- a/Dockerfile.kubectl
+++ b/Dockerfile.kubectl
@@ -3,6 +3,8 @@ FROM bash:5.3.0-alpine3.22
 ARG TARGETARCH
 ARG TARGETOS
 
-ENV KUBECTL_VERSION="v1.27.15"
-ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /usr/bin/kubectl
+RUN apk update && apk upgrade --no-cache
+
+ENV KUBECTL_VERSION="v1.35.3"
+ADD https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /usr/bin/kubectl
 RUN chmod +x /usr/bin/kubectl

--- a/Dockerfile.kubectl-ubi
+++ b/Dockerfile.kubectl-ubi
@@ -4,8 +4,10 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG BUILD_TAG
 
-ENV KUBECTL_VERSION="v1.26.4"
-ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /usr/bin/kubectl
+RUN microdnf update -y && microdnf clean all
+
+ENV KUBECTL_VERSION="v1.35.3"
+ADD https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl /usr/bin/kubectl
 RUN chmod +x /usr/bin/kubectl
 
 ENV SUMMARY="UBI based Kubectl Sumo Logic Tools image" \


### PR DESCRIPTION
- Add apk update && apk upgrade to Dockerfile.kubectl for OpenSSL CVE fixes
- Add microdnf update to Dockerfile.kubectl-ubi for package updates
- Bump kubectl from v1.27.15/v1.26.4 to v1.35.3
- Change download URL from storage.googleapis.com to dl.k8s.io