### PR TITLE
ci: add renovate

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+# Add 'documentation' label to any change to *.md files
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: ['**/*.md']
+
+# Add 'docker' label to any change in docker related files
+docker:
+  - changed-files:
+      - any-glob-to-any-file: ['**/Dockerfile*', '**/.dockerignore']
+
+# Add 'github_actions' label to any change .github/ directory
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/**']
+
+# Add 'go' label to any change *.go files
+go:
+  - changed-files:
+      - any-glob-to-any-file: ['**/*.go']
+
+osc:
+  - changed-files:
+      - any-glob-to-any-file: ['**']

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,56 @@
+name: Renovate-scheduler
+on:
+  schedule:
+    - cron: "30 18 * * *" # every day at 18:30 UTC (12:00 AM IST)
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Log level"
+        type: choice
+        default: "info"
+        options:
+          - "info"
+          - "debug"
+          - "warn"
+      dryRun:
+        description: "Dry-run: full (simulate PRs), lookup (check updates only), extract (parse deps only)"
+        type: choice
+        default: ""
+        options:
+          - ""
+          - "full"
+          - "lookup"
+          - "extract"
+
+concurrency: renovate
+
+jobs:
+  renovate:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate Renovate config
+        uses: rinchsan/renovate-config-validator@v0.2.1
+        with:
+          pattern: renovate.json5
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+
+      - name: Renovate run
+        uses: renovatebot/github-action@v46.1.14
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun || '' }}
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_USERNAME: "renovatebot-sumologic[bot]"
+          RENOVATE_GIT_AUTHOR: "renovatebot-sumologic[bot] <279692411+renovatebot-sumologic[bot]@users.noreply.github.com>"
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          configurationFile: renovate.json5

--- a/renovate.json5
+++ b/renovate.json5
@@ -12,7 +12,35 @@
   commitMessageAction: 'bump',
   commitMessageExtra: '{{#if isSingleVersion}}from {{{currentValue}}} to {{{newValue}}}{{/if}}',
   enabledManagers: [
-    'helm-values',
+    'custom.regex',
+  ],
+  customManagers: [
+    {
+      customType: 'regex',
+      description: 'Update Helm version in Dockerfile',
+      fileMatch: ['^Dockerfile$'],
+      matchStrings: ['ENV HELM_VERSION="(?<currentValue>.*?)"'],
+      depNameTemplate: 'helm/helm',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.*)$',
+    },
+    {
+      customType: 'regex',
+      description: 'Update yq version in Dockerfile',
+      fileMatch: ['^Dockerfile$'],
+      matchStrings: ['ENV YQ_VERSION="(?<currentValue>.*?)"'],
+      depNameTemplate: 'mikefarah/yq',
+      datasourceTemplate: 'github-releases',
+      extractVersionTemplate: '^v(?<version>.*)$',
+    },
+    {
+      customType: 'regex',
+      description: 'Update kubectl version in Dockerfiles',
+      fileMatch: ['^Dockerfile'],
+      matchStrings: ['ENV KUBECTL_VERSION="(?<currentValue>.*?)"'],
+      depNameTemplate: 'kubernetes/kubernetes',
+      datasourceTemplate: 'github-releases',
+    },
   ],
   packageRules: [
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,26 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'config:recommended',
+  ],
+  dependencyDashboardApproval: false,
+  recreateWhen: 'always',
+  prHourlyLimit: 10,
+  labels: [
+    'dependencies',
+  ],
+  commitMessageAction: 'bump',
+  commitMessageExtra: '{{#if isSingleVersion}}from {{{currentValue}}} to {{{newValue}}}{{/if}}',
+  enabledManagers: [
+    'helm-values',
+  ],
+  packageRules: [
+    {
+      description: 'Add chore(deps) prefix to all dependency update commits',
+      commitMessagePrefix: 'chore(deps):',
+      matchPackageNames: [
+        '/.*/',
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

Add self-hosted Renovate bot to manage dependency updates for pinned tool versions in Dockerfiles that Dependabot cannot handle.

## What Renovate manages

Uses `custom.regex` managers to track versions installed via `ENV` + `curl` in Dockerfiles:

- **Helm** (`helm/helm`) — `Dockerfile`
- **yq** (`mikefarah/yq`) — `Dockerfile`
- **kubectl** (`kubernetes/kubernetes`) — all `Dockerfile*` variants

## What Dependabot continues to manage

- Go modules (`src/go`)
- Docker base images (`golang`, `rust`, `alpine`, `ubi`)
- GitHub Actions
- Cargo dependencies

## How it works

- Runs daily at 18:30 UTC via a scheduled GitHub Actions workflow
- Uses a GitHub App (`renovatebot-sumologic`) for authentication
- Supports manual triggers with configurable log level and dry-run mode
- Validates `renovate.json5` config before each run

## Other changes

- Adds `.github/labeler.yml` for automatic PR labeling based on changed files
